### PR TITLE
Fix proper confirmations and meditation prompts

### DIFF
--- a/PSKoans.psm1
+++ b/PSKoans.psm1
@@ -207,6 +207,9 @@ function Initialize-KoanDirectory {
         Copy-Item -Path "$PSScriptRoot/Koans" -Recurse -Destination $script:KoanFolder
         Write-Verbose "Koans copied to '$script:KoanFolder'"
     }
+    else {
+        Write-Verbose "Operation cancelled; no modifications made to koans folder."
+    }
 }
 
 $script:ZenSayings = Import-CliXml -Path ($PSScriptRoot | Join-Path -ChildPath "Data/Meditations.clixml")

--- a/PSKoans.psm1
+++ b/PSKoans.psm1
@@ -187,37 +187,31 @@ You may run 'rake -Meditate' to begin your meditation.
 "@
 }
 function Initialize-KoanDirectory {
-	<#
+    <#
 	.NOTES
 		Name: Initialize-KoanDirectory
 		Author: vexx32
 	.SYNOPSIS
 		Provides a blank slate for Koans.
 	.DESCRIPTION
-		If Koans folder already exists, the folder(s) are overwritten. Otherwise a new folder structure is produced.
-	.Parameter FirstImport
-		Indicates that the folder structure should be created/refreshed.
-	#>
-	[CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
-	param(
-		[Parameter()]
-		[switch]
-		$FirstImport
-	)
-	if ($FirstImport -or $PSCmdlet.ShouldProcess($script:KoanFolder, "Restore the koans to a blank slate")) {
-		if (Test-Path -Path $script:KoanFolder) {
-			Write-Verbose "Removing the entire koans folder..."
-			Remove-Item -Recurse -Path $script:KoanFolder -Force
-		}
-		Write-Debug "Copying koans to folder"
-		Copy-Item -Path "$PSScriptRoot/Koans" -Recurse -Destination $script:KoanFolder
-		Write-Verbose "Koans copied to '$script:KoanFolder'"
-	}
+        If Koans folder already exists, the folder(s) are overwritten. Otherwise a new folder structure is produced.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
+    param()
+    if ($FirstImport -or $PSCmdlet.ShouldProcess($script:KoanFolder, "Restore the koans to a blank slate")) {
+        if (Test-Path -Path $script:KoanFolder) {
+            Write-Verbose "Removing the entire koans folder..."
+            Remove-Item -Recurse -Path $script:KoanFolder -Force
+        }
+        Write-Debug "Copying koans to folder"
+        Copy-Item -Path "$PSScriptRoot/Koans" -Recurse -Destination $script:KoanFolder
+        Write-Verbose "Koans copied to '$script:KoanFolder'"
+    }
 }
 
 $script:ZenSayings = Import-CliXml -Path ($PSScriptRoot | Join-Path -ChildPath "Data/Meditations.clixml")
 $script:KoanFolder = $Home | Join-Path -ChildPath 'PSKoans'
 
 if (-not (Test-Path -Path $script:KoanFolder)) {
-	Initialize-KoanDirectory -FirstImport
+	Initialize-KoanDirectory -Confirm:$false
 }

--- a/PSKoans.psm1
+++ b/PSKoans.psm1
@@ -198,7 +198,7 @@ function Initialize-KoanDirectory {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
     param()
-    if ($FirstImport -or $PSCmdlet.ShouldProcess($script:KoanFolder, "Restore the koans to a blank slate")) {
+    if ($PSCmdlet.ShouldProcess($script:KoanFolder, "Restore the koans to a blank slate")) {
         if (Test-Path -Path $script:KoanFolder) {
             Write-Verbose "Removing the entire koans folder..."
             Remove-Item -Recurse -Path $script:KoanFolder -Force

--- a/PSKoans.psm1
+++ b/PSKoans.psm1
@@ -145,8 +145,8 @@ function Write-MeditationPrompt {
 
 	if ($PSCmdlet.ParameterSetName -eq 'Greeting') {
 		Write-Host -ForegroundColor Cyan @"
-Welcome, seeker of enlightenment.
-Please wait a moment while we examine your karma...
+    Welcome, seeker of enlightenment.
+    Please wait a moment while we examine your karma...
 
 "@
 return
@@ -157,9 +157,9 @@ Write-Host @Red @"
 Start-Sleep @SleepTime
 Write-Host @Blue @"
 
-You have not yet reached enlightenment.
+    You have not yet reached enlightenment.
 
-The answers you seek...
+    The answers you seek...
 
 "@
 	Write-Host @Red @"
@@ -168,7 +168,7 @@ $Expectation
 Start-Sleep @SleepTime
 Write-Host @Blue @"
 
-Please meditate on the following code:
+    Please meditate on the following code:
 
 "@
 Write-Host @Red @"
@@ -178,9 +178,9 @@ $Meditation
 Start-Sleep @SleepTime
 Write-Host @Blue @"
 
-$($Koan -replace "`n","`n    ")
+    $($Koan -replace "`n","`n    ")
 
-Your path thus far:
+    Your path thus far:
 
 "@
 	$ProgressAmount = "$KoansPassed/$TotalKoans"

--- a/PSKoans.psm1
+++ b/PSKoans.psm1
@@ -8,8 +8,6 @@ function Get-Enlightenment {
 	.DESCRIPTION
         Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
         corrections for success.
-	.PARAMETER Clear
-		Clear the screen before giving feedback. Defaults to True.
 	.PARAMETER Meditate
 		Opens your local koan folder.
 	.PARAMETER Reset


### PR DESCRIPTION
Some minor spacing issues need to be fixed in the meditation prompt.

Plus, see issue #15; Intialize-KoanDirectory prompt was not functioning as expected. Rather than a custom switch, we can just use the builtin -Confirm switch and have the ConfirmImpact set to High for that function to auto-prompt by default.