### PR TITLE
Cleaned files of trailing whitespace

### DIFF
--- a/Koans/01_Foundations/03_AboutFunctions.Tests.ps1
+++ b/Koans/01_Foundations/03_AboutFunctions.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Functions" {
             PowerShell function names are named in convention following
             the cmdlets; Verb-Noun. To see the list of approved
             PowerShell verbs, run 'Get-Verb' in the console.
-            
+
             There are many methods of sending output from a function.
         #>
 
@@ -58,7 +58,7 @@ Describe "Functions" {
 
         Add-Numbers 1 7 | Should -Be __
         Add-Numbers __ 15 | Should -Be 31
-        
+
         # Values can be passed to specified parameters
         Add-Numbers -Number2 8 -Number1 12 | Should -Be 20
     }
@@ -83,7 +83,7 @@ Describe "Script Block" {
             Script blocks can be used to group commands without defining a function.
             These can be used for various things, most commonly for parameters or
             defining a sequence of actions to be executed multiple times.
-            
+
             Many PowerShell cmdlets take script blocks as parameters, particularly pipeline cmdlets.
         #>
         $Script = {

--- a/Koans/01_Foundations/04_AboutOrderOfOperations.Tests.ps1
+++ b/Koans/01_Foundations/04_AboutOrderOfOperations.Tests.ps1
@@ -12,7 +12,7 @@
     to evaluate first.
 #>
 Describe "Order of Operations" {
-    
+
     It "requires parameter argument expressions to be enclosed in parentheses" {
         function Add-Numbers {
             param(
@@ -27,7 +27,7 @@ Describe "Order of Operations" {
         Add-Numbers (4 + 1) 18 | Should -Be __
         Add-Numbers 3 * 4 7 | Should -Be 19 # Add parentheses to the function call to make this true.
     }
-    
+
     It "will evaluate an entire expression if it is the first element in a pipeline" {
         # A pipe character evaluates everything before it on the line before 
         # passing along the value(s).

--- a/Koans/03_Constructs/01_AboutLists.Tests.ps1
+++ b/Koans/03_Constructs/01_AboutLists.Tests.ps1
@@ -37,12 +37,12 @@
 #>
 
 Describe "Lists" {
-    It "can enforce strict typing on its contents" {        
+    It "can enforce strict typing on its contents" {
         # New integer-only List
         $IntList = New-Object System.Collections.Generic.List[int]
         $IntList.Add(7)
         $IntList.Add(5.34)
-        
+
         # Items are accessed by index just like arrays.
         $IntList[0] | Should -Be __
         $IntList[1] | Should -Be __
@@ -84,12 +84,12 @@ Describe "Lists" {
         # Now see if you can reduce the list down to only two values using the
         # .RemoveRange($Index, $Count) method
         # Feel free to add an additional ' | Should -Be ' test if you need it to guide your way!
-        
+
         $List | Should -Be @('12', '10')
     }
     It 'allows you to remove multiple entries based on conditions' {
         $List = [System.Collections.Generic.List[string]]@(1..11)
-        
+
         # This method takes a lambda expression in C#, which translates to a script block for PowerShell
         # It also outputs a $true or $false depending on whether elements were removed, so we'll check that
         $List.RemoveAll({
@@ -104,7 +104,7 @@ Describe "Lists" {
         $List.RemoveAll({
             param($_)
             # Change this expression to make the assertions below true
-            
+
         }) | Should -BeTrue
 
         $List | Should -Be @(1, 3, 5, 7, 11)

--- a/Koans/03_Constructs/02_AboutLoopsAndPipelines.Tests.ps1
+++ b/Koans/03_Constructs/02_AboutLoopsAndPipelines.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Pipelines and Loops" {
     It "works with many cmdlets to efficiently process input" {
         # The pipeline takes each element of the array and feeds them one by one into the next cmdlet
         1..5 | ForEach-Object {
-            <# 
+            <#
                 ForEach-Object is a cmdlet that utilises the pipeline to create a sort of loop, where
                 each object that it receives from the pipeline has the same set of actions performed
                 on it.


### PR DESCRIPTION
For VSCode users to stop seeing green squiggly line indicating trailing whitespace on lines