### PR TITLE
Koans/about modules

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -110,6 +110,24 @@ Describe 'New-Module' {
         New-Module is rarely used in practice, but is capable of dynamically generating
         a module in-memory without needing a file on disk.
     #>
+
+    It 'creates a dynamic module object' {
+        $Module = New-Module -Name 'PSKoans_TestModule' -ScriptBlock {}
+        $Module | Should -Not -BeNullOrEmpty
+    }
+
+    It 'has many properties with $null defaults' {
+        # For most modules, ModuleBase lists their primary storage location
+        $Module.ModuleBase | Should -Be __
+    }
+
+    It 'supplies the module with a GUID based random path' {
+        '__' | Should -Be $Module.Path
+    }
+
+    AfterAll {
+        Remove-Module -Name 'PSKoans_TestModule'
+    }
 }
 
 Describe 'Import-Module' {

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -132,8 +132,7 @@ Describe 'Import-Module' {
         }
 
         It 'imports the module into the current session' {
-            $ImportedModule = Get-Module -Name 'PSKoans_ImportModuleTest' |
-                Select-Object -First 1
+            $ImportedModule = Get-Module -Name 'PSKoans_ImportModuleTest'
 
             $ImportedModule.ExportedCommands.Keys | Should -BeNull
             '__' | Should -Be $ImportedModule.Name
@@ -156,8 +155,7 @@ Describe 'Import-Module' {
         }
 
         It 'imports the module into the current session' {
-            $ImportedModule = Get-Module -Name '__' |
-                Select-Object -First 1
+            $ImportedModule = Get-Module -Name '__'
             $ImportedModule | Should -Not -BeNullOrEmpty
         }
 

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -114,21 +114,11 @@ Describe 'Import-Module' {
     #>
     Context 'Importing Installed Modules' {
         BeforeAll {
-            Mock Import-Module {
-                $Name = $Name | Select-Object -First 1
-                $Module = New-Module -Name $Name -ScriptBlock {}
-                $CommandParams = @{
-                    Name        = 'Import-Module'
-                    Module      = 'Microsoft.PowerShell.Core'
-                    CommandType = 'Cmdlet'
-                }
-
-                & (Get-Command @CommandParams) $Module
-            }
+            $Module = New-Module -Name 'PSKoans_ImportModuleTest' {}
         }
 
         It 'does not produce output' {
-            Import-Module -Name 'PSKoans_ImportModuleTest' | Should -BeNull
+            Import-Module $Module | Should -BeNull
         }
 
         It 'imports the module into the current session' {

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -188,4 +188,6 @@ Describe 'Import-Module' {
 
         Get-Help *-Module
         Get-Command -Noun Module
+
+    You'll need Install-Module to install new ones, at least!
 #>

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -82,15 +82,15 @@ Describe 'Find-Module' {
             }, Description
         }
 
-        $Module = Find-Module -Name 'Pester'
+        $Module = Find-Module -Name 'Pester' | Select-Object -First 1
     }
 
     It 'finds modules that can be installed' {
-        $Module.Name | Select-Object -First 1 | Should -Be '__'
+        '__' | Should -Be $Module.Name
     }
 
     It 'lists the latest version of the module' {
-        $Module.Version | Select-Object -First 1 | Should -Be '__'
+        '__' | Should -Be $Module.Version
     }
 
     It 'indicates which repository stores the module' {
@@ -98,10 +98,10 @@ Describe 'Find-Module' {
             Unless an additional repository has been configured, all modules
             from Find-Module will come from the PowerShell Gallery.
         #>
-        $Module.Repository | Should -Be '__'
+        '__' | Should -Be $Module.Repository
     }
     It 'gives a brief description of the module' {
-        $Module.Description | Should -Match '__'
+        '__' | Should -Match  $Module.Description
     }
 }
 
@@ -115,6 +115,7 @@ Describe 'Import-Module' {
     Context 'Importing Installed Modules' {
         BeforeAll {
             Mock Import-Module {
+                $Name = $Name | Select-Object -First 1
                 $Module = New-Module -Name $Name -ScriptBlock {}
                 $CommandParams = @{
                     Name        = 'Import-Module'
@@ -131,9 +132,10 @@ Describe 'Import-Module' {
         }
 
         It 'imports the module into the current session' {
-            $ImportedModule = Get-Module -Name 'PSKoans_ImportModuleTest'
+            $ImportedModule = Get-Module -Name 'PSKoans_ImportModuleTest' |
+                Select-Object -First 1
 
-            $ImportedModule.ExportedCommands | Should -BeNull
+            $ImportedModule.ExportedCommands.Keys | Should -BeNull
             '__' | Should -Be $ImportedModule.Name
         }
     }
@@ -154,12 +156,13 @@ Describe 'Import-Module' {
         }
 
         It 'imports the module into the current session' {
-            $ImportedModule = Get-Module -Name '__'
-            '__' | Should -Be $ImportedModule.ExportedCommands
+            $ImportedModule = Get-Module -Name '__' |
+                Select-Object -First 1
+            $ImportedModule | Should -Not -BeNullOrEmpty
         }
 
         It 'makes the module''s exported commands available for use' {
-            @('__') | Should -Be $ImportedModule.ExportedCommands
+            @('__') | Should -Be $ImportedModule.ExportedCommands.Keys
         }
     }
 }

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -104,6 +104,65 @@ Describe 'Find-Module' {
         $Module.Description | Should -Match '__'
     }
 }
+
+Describe 'Import-Module' {
+    <#
+        Import-Module
+
+        Import-Module is an auxiliary cmdlet that imports the requested module
+        into the current session. It is capable of both importing
+    #>
+    Context 'Importing Installed Modules' {
+        BeforeAll {
+            Mock Import-Module {
+                $Module = New-Module -Name $Name -ScriptBlock {}
+                $CommandParams = @{
+                    Name        = 'Import-Module'
+                    Module      = 'Microsoft.PowerShell.Core'
+                    CommandType = 'Cmdlet'
+                }
+
+                & (Get-Command @CommandParams) $Module
+            }
+        }
+
+        It 'does not produce output' {
+            Import-Module -Name 'PSKoans_ImportModuleTest' | Should -BeNull
+        }
+
+        It 'imports the module into the current session' {
+            $ImportedModule = Get-Module -Name 'PSKoans_ImportModuleTest'
+
+            $ImportedModule.ExportedCommands | Should -BeNull
+            '__' | Should -Be $ImportedModule.Name
+        }
+    }
+
+    Context 'Importing Module From File' {
+        BeforeAll {
+            $ModuleScript = {
+                function Test-ModuleFunction {
+                    __ # Fill in the correct value here
+                }
+                Export-ModuleMember 'Test-ModuleFunction'
+            }
+            $ModuleScript.ToString() | Set-Content -Path 'TestDrive:\TestModule.psm1'
+        }
+
+        It 'does not produce output' {
+            Import-Module 'TestDrive:\TestModule.psm1' | Should -Be __
+        }
+
+        It 'imports the module into the current session' {
+            $ImportedModule = Get-Module -Name '__'
+            '__' | Should -Be $ImportedModule.ExportedCommands
+        }
+
+        It 'makes the module''s exported commands available for use' {
+            @('__') | Should -Be $ImportedModule.ExportedCommands
+        }
+    }
+}
 <#
     Other *-Module Cmdlets
 

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -19,3 +19,25 @@ param()
     Script modules commonly consist of .psm1, .psd1, .ps1 and other files, and are
     one of the more common module types.
 #>
+Describe 'Get-Module' {
+
+}
+
+Describe 'Find-Module' {
+    BeforeAll {
+        <#
+            This will effectively produce similar output to the Find-Module cmdlet
+            while only searching the local modules instead of online ones. 'Mock'
+            is a Pester command that will be covered later.
+        #>
+        Mock Find-Module {
+            Get-Module -ListAvailable -Name $Name |
+                Select-Object -Property Version, Name, @{
+                Name       = 'Repository'
+                Expression = {'PSGallery'}
+            }, Description
+        }
+    }
+}
+
+Describe 'Save-Module'

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -1,3 +1,21 @@
 #Requires -Module PSKoans
 [Koan(Position = 212)]
 param()
+<#
+    Modules
+
+    PowerShell is built from various types of modules, which come in three flavours:
+        - Script modules
+        - Manifest modules
+        - Binary modules
+
+    Manifest modules are the least common, consisting only of a single .psd1 file;
+    their primary code is often stored in a core library of PowerShell and is not
+    considered part of 'the module' itself, merely exposed by it.
+
+    Binary modules are compiled from C# using the PowerShell libraries and tend to
+    be in .dll formats with other files providing metadata.
+
+    Script modules commonly consist of .psm1, .psd1, .ps1 and other files, and are
+    one of the more common module types.
+#>

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -21,6 +21,42 @@ param()
 #>
 Describe 'Get-Module' {
 
+    It 'returns a list of modules in the current session' {
+        # To list all installed modules, use the -ListAvailable switch.
+
+        $Modules = Get-Module
+        $FirstThreeModules = @('__', '__', '__')
+        $VersionOfThirdModule = '__'
+        $TypeOf6thModule = '__'
+
+        $FirstThreeModules | Should -Be $Modules[0..2].Name
+        $VersionOfThirdModule | Should -Be $Module[2].Version
+        $TypeOf6thModule | Should -Be $Modules[5].ModuleType
+    }
+
+    It 'can filter by module name' {
+        $Pester = Get-Module -Name 'Pester'
+
+        $ThreeExportedCommands = @('__', '__', '__')
+
+        $ThreeExportedCommands | Should -BeIn $Pester.ExportedCommands.Values.Name
+    }
+
+    It 'can list nested modules' {
+        $AllModules = Get-Module -All
+
+        $Axioms = $AllModules | Where-Object Name -eq 'Axiom'
+
+        $Commands = @('__', '__', '__')
+        $Commands | Should -BeIn $Axioms.ExportedCommands.Values.Name
+        <#
+            Despite us being able to 'see' this module, we cannot use its commands as it
+            is only available in Pester's module scope.
+        #>
+        {if ($Commands[1] -in $Axioms.ExportedCommands.Values.Name) {
+            & $Commands[1]
+        }} | Should -Throw
+    }
 }
 
 Describe 'Find-Module' {
@@ -40,4 +76,6 @@ Describe 'Find-Module' {
     }
 }
 
-Describe 'Save-Module'
+Describe 'Save-Module' {
+
+}

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -81,9 +81,34 @@ Describe 'Find-Module' {
                 Expression = {'PSGallery'}
             }, Description
         }
+
+        $Module = Find-Module -Name 'Pester'
+    }
+
+    It 'finds modules that can be installed' {
+        $Module.Name | Select-Object -First 1 | Should -Be '__'
+    }
+
+    It 'lists the latest version of the module' {
+        $Module.Version | Select-Object -First 1 | Should -Be '__'
+    }
+
+    It 'indicates which repository stores the module' {
+        <#
+            Unless an additional repository has been configured, all modules
+            from Find-Module will come from the PowerShell Gallery.
+        #>
+        $Module.Repository | Should -Be '__'
+    }
+    It 'gives a brief description of the module' {
+        $Module.Description | Should -Match '__'
     }
 }
+<#
+    Other *-Module Cmdlets
 
-Describe 'Save-Module' {
+    Check out the other module cmdlets with:
 
-}
+        Get-Help *-Module
+        Get-Command -Noun Module
+#>

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -105,10 +105,15 @@ Describe 'Find-Module' {
     }
 }
 
+Describe 'New-Module' {
+    <#
+        New-Module is rarely used in practice, but is capable of dynamically generating
+        a module in-memory without needing a file on disk.
+    #>
+}
+
 Describe 'Import-Module' {
     <#
-        Import-Module
-
         Import-Module is an auxiliary cmdlet that imports the requested module
         into the current session. It is capable of both importing
     #>

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -165,6 +165,10 @@ Describe 'Import-Module' {
             @('__') | Should -Be $ImportedModule.ExportedCommands.Keys
         }
     }
+
+    AfterAll {
+        Remove-Module -Name 'TestModule', 'PSKoans_ImportModuleTest'
+    }
 }
 <#
     Other *-Module Cmdlets

--- a/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutModules.Koans.ps1
@@ -20,7 +20,10 @@ param()
     one of the more common module types.
 #>
 Describe 'Get-Module' {
-
+    <#
+        Get-Module is used to find out which modules are presently loaded into
+        the session, or to search available modules on the computer.
+    #>
     It 'returns a list of modules in the current session' {
         # To list all installed modules, use the -ListAvailable switch.
 
@@ -54,12 +57,17 @@ Describe 'Get-Module' {
             is only available in Pester's module scope.
         #>
         {if ($Commands[1] -in $Axioms.ExportedCommands.Values.Name) {
-            & $Commands[1]
-        }} | Should -Throw
+                & $Commands[1]
+            }} | Should -Throw
     }
 }
 
 Describe 'Find-Module' {
+    <#
+        Find-Module is very similar to Get-Module, except that it searches all
+        registered PSRepositories in order to find a module available for
+        install.
+    #>
     BeforeAll {
         <#
             This will effectively produce similar output to the Find-Module cmdlet

--- a/PSKoans/Private/Measure-Koans.ps1
+++ b/PSKoans/Private/Measure-Koans.ps1
@@ -27,7 +27,7 @@ function Measure-Koans {
     param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [ValidateNotNull()]
-        [System.Management.Automation.ExternalScriptInfo[]]
+        [System.Management.Automation.CommandInfo[]]
         $KoanInfo
     )
     begin {

--- a/PSKoans/Private/Measure-Koans.ps1
+++ b/PSKoans/Private/Measure-Koans.ps1
@@ -1,0 +1,48 @@
+function Measure-Koans {
+    <#
+    .SYNOPSIS
+    Counts the number of koans in the provided ExternalScriptInfo objects.
+
+    .DESCRIPTION
+    Traverses the AST of the script blocks taken from the Get-Command output of the koan
+    files to find all of the 'It' blocks in order to count the total number of Pester
+    tests present in the file.
+
+    When provided with a piped list of ExternalScriptInfo objects, sums the entire
+    collection's 'It' blocks and returns a single integer sum.
+
+    .PARAMETER KoanInfo
+    Takes an array of ExternalScriptInfo objects (as provided from Get-Command when
+    passed the path to an external .ps1 script file).
+
+    .EXAMPLE
+    PS> Get-Command .\KoanDirectory\*\*.ps1 | Measure-Koans
+    422
+
+    .NOTES
+    Author: Joel Sallow
+    Module: PSKoans
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [VaidateNotNull()]
+        [System.Management.Automation.ExternalScriptInfo[]]
+        $KoanInfo
+    )
+    begin {
+        $KoanCount = 0
+    }
+    process {
+        $KoanCount += $KoanInfo.ScriptBlock.Ast.FindAll(
+            {
+                param($Item)
+                $Item -is [System.Management.Automation.Language.CommandAst] -and
+                $Item.GetCommandName() -eq 'It'
+            }, $true
+        ).Count
+    }
+    end {
+        $KoanCount
+    }
+}

--- a/PSKoans/Private/Measure-Koans.ps1
+++ b/PSKoans/Private/Measure-Koans.ps1
@@ -25,8 +25,8 @@ function Measure-Koans {
     #>
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [VaidateNotNull()]
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [ValidateNotNull()]
         [System.Management.Automation.ExternalScriptInfo[]]
         $KoanInfo
     )

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -37,7 +37,7 @@ function Measure-Karma {
     [Alias('Rake', 'Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate')]
     param(
         [Parameter(Mandatory, ParameterSetName = "OpenFolder")]
-        [Alias('Koans', 'Contemplate', 'Meditate')]
+        [Alias('Koans', 'Meditate')]
         [switch]
         $Contemplate,
 

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -1,19 +1,19 @@
 function Measure-Karma {
     <#
 	.NOTES
-		Name: Get-Enlightenment
-		Author: vexx32
+		Name: Measure-Karma
+		Author: Joel Sallow
 	.SYNOPSIS
 		Reflect on your progress and check your answers.
 	.DESCRIPTION
         Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
         corrections for success.
-	.PARAMETER Meditate
+	.PARAMETER Contemplate
 		Opens your local koan folder.
 	.PARAMETER Reset
         Resets everything in your local koan folder to a blank slate. Use with caution.
     .EXAMPLE
-        PS> Get-Enlightenment
+        PS> Measure-Karma
 
         Assesses the results of the Pester tests, and builds the meditation prompt.
     .EXAMPLE
@@ -23,10 +23,10 @@ function Measure-Karma {
     .EXAMPLE
         PS> meditate -Contemplate
 
-        Opens the user's koans folder, housed in $home\PSKoans. If VS Code is in $env:Path, opens in
-        VS Code.
+        Opens the user's koans folder, housed in '$home\PSKoans'. If VS Code is in $env:Path,
+        opens in VS Code.
     .EXAMPLE
-        PS> rake -Reset
+        PS> Measure-Karma -Reset
 
         Prompts for confirmation, before wiping out the user's koans folder and restoring it back
         to its initial state.
@@ -66,18 +66,10 @@ function Measure-Karma {
                 Get-Command {$_.FullName} |
                 Where-Object {$_.ScriptBlock.Attributes.TypeID -match 'KoanAttribute'} |
                 Sort-Object {
-                $_.ScriptBlock.Attributes.Where( {
-                        $_.TypeID -match 'KoanAttribute'
-                    }).Position
+                $_.ScriptBlock.Attributes.Where( {$_.TypeID -match 'KoanAttribute'}).Position
             }
 
-            $TotalKoans = $SortedKoanList.ScriptBlock.Ast.FindAll(
-                {
-                    param($Item)
-                    $Item -is [System.Management.Automation.Language.CommandAst] -and
-                    $Item.GetCommandName() -eq 'It'
-                }, $true
-            ).Count
+            $TotalKoans = $SortedKoanList | Measure-Koans
 
             $KoansPassed = 0
 

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -21,7 +21,7 @@ function Measure-Karma {
 
         Assesses the results of the Pester tests, and builds the meditation prompt.
     .EXAMPLE
-        PS> rake -Meditate
+        PS> meditate -Contemplate
 
         Opens the user's koans folder, housed in $home\PSKoans. If VS Code is in $env:Path, opens in
         VS Code.
@@ -34,11 +34,12 @@ function Measure-Karma {
         https://github.com/vexx32/PSKoans
 	#>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Default")]
-    [Alias('Rake', 'Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment')]
+    [Alias('Rake', 'Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate')]
     param(
-        [Parameter(Mandatory, ParameterSetName = "Meditate")]
+        [Parameter(Mandatory, ParameterSetName = "OpenFolder")]
+        [Alias('Koans', 'Contemplate', 'Meditate')]
         [switch]
-        $Meditate,
+        $Contemplate,
 
         [Parameter(Mandatory, ParameterSetName = "Reset")]
         [switch]
@@ -48,7 +49,7 @@ function Measure-Karma {
         "Reset" {
             Initialize-KoanDirectory
         }
-        "Meditate" {
+        "OpenFolder" {
             if (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
                 Start-Process -FilePath 'code' -ArgumentList $env:PSKoans_Folder -NoNewWindow
             }
@@ -65,10 +66,10 @@ function Measure-Karma {
                 Get-Command {$_.FullName} |
                 Where-Object {$_.ScriptBlock.Attributes.TypeID -match 'KoanAttribute'} |
                 Sort-Object {
-                    $_.ScriptBlock.Attributes.Where( {
-                            $_.TypeID -match 'KoanAttribute'
-                        }).Position
-                }
+                $_.ScriptBlock.Attributes.Where( {
+                        $_.TypeID -match 'KoanAttribute'
+                    }).Position
+            }
 
             $TotalKoans = $SortedKoanList.ScriptBlock.Ast.FindAll(
                 {

--- a/Tests/Functions/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Measure-Karma.Tests.ps1
@@ -45,7 +45,7 @@ InModuleScope 'PSKoans' {
             }
         }
 
-        Context 'With -Meditate Switch' {
+        Context 'With -Contemplate Switch' {
 
             Context 'VS Code Installed' {
                 BeforeAll {

--- a/Tests/Functions/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Measure-Karma.Tests.ps1
@@ -54,7 +54,7 @@ InModuleScope 'PSKoans' {
                 }
 
                 It 'should start VS Code with Start-Process' {
-                    Measure-Karma -Meditate | Should -Be 'code'
+                    Measure-Karma -Contemplate | Should -Be 'code'
 
                     Assert-MockCalled Get-Command -Times 1
                     Assert-MockCalled Start-Process -Times 1

--- a/Tests/Functions/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Measure-Karma.Tests.ps1
@@ -8,6 +8,7 @@ InModuleScope 'PSKoans' {
                 Mock Clear-Host
                 Mock Write-MeditationPrompt
                 Mock Invoke-Pester
+                Mock Measure-Koans
             }
 
             It 'should not produce output' {
@@ -20,6 +21,10 @@ InModuleScope 'PSKoans' {
 
             It 'should write the meditation prompts' {
                 Assert-MockCalled Write-MeditationPrompt -Times 2
+            }
+
+            It 'should count the koans' {
+                Assert-MockCalled Measure-Koans
             }
 
             It 'should Invoke-Pester on each of the koans' {

--- a/Tests/Functions/Measure-Koans.Tests.ps1
+++ b/Tests/Functions/Measure-Koans.Tests.ps1
@@ -1,0 +1,13 @@
+#Requires -Module PSKoans
+
+InModuleScope 'PSKoans' {
+    Describe 'Measure-Koans' {
+
+        It 'should correctly count the number of It blocks in a file' {
+            Get-Item -Path "$script:ModuleFolder\..\Tests\Functions\Measure-Koans.Tests.ps1" |
+            Get-Command {$_.FullName} |
+                Measure-Koans |
+                Should -Be 1
+        }
+    }
+}


### PR DESCRIPTION
Adds koans for the *-module cmdlets.

Some that don't make a lot of sense to mock (e.g., Install-Module; doesn't produce output and causes system changes) have been omitted for the time being.