### PR TITLE
Changes ExpectedType to ExpectedMessage

### DIFF
--- a/PSKoans/Koans/Foundations/AboutAssignmentAndArithmetic.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutAssignmentAndArithmetic.Koans.ps1
@@ -133,11 +133,11 @@ Describe 'Arithmetic Operators' {
             {
                 $String = 'hello!'
                 $String % 4
-            }  | Should -Throw -ExceptionType __
+            }  | Should -Throw -ExpectedMessage __
             {
                 $Array = 1, 10, 20
                 $Array % 4
-            } | Should -Throw -ExceptionType __
+            } | Should -Throw -ExpectedMessage __
         }
     }
 }


### PR DESCRIPTION
ExpectedType is [System.Management.Automation.RuntimeException] and must be enclosed in parentheses. I suggest testing the message may be more effective (a partial message will match).