### PR TITLE
Makes -Be value an array of blanks

### DIFF
--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -68,7 +68,7 @@ Describe 'Strings' {
             $AlternateString = "This is a ""string"" value."
 
             # A mirror image, a familiar pattern, reflected in the glass.
-            $String, $AlternateString | Should -Be '__'
+            $String, $AlternateString | Should -Be @('__', '__')
         }
 
         It 'can insert special characters with escape sequences' {


### PR DESCRIPTION
Example suggests a single string. Repetition is required to satisfy the test case.