### PR TITLE
Updates about type operators

### DIFF
--- a/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
@@ -59,7 +59,7 @@ Describe 'Type Operators' {
 
             $Casting | Should -Throw -ErrorId __
             $Conversion | Should -Not -Throw
-            $Conversion | Should -Be __
+            $Conversion.Invoke() | Should -Be __
         }
     }
 }

--- a/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
@@ -57,7 +57,7 @@ Describe 'Type Operators' {
                 'string' -as [int]
             }
 
-            $Casting | Should -Throw -ExceptionType __
+            $Casting | Should -Throw -ErrorId __
             $Conversion | Should -Not -Throw
             $Conversion | Should -Be __
         }


### PR DESCRIPTION
Replaces ExceptionType (requires System.Management.Automation.RuntimeException) for ErrorId (expects InvalidCastFromStringToInteger).

Invokes Conversion script block. Expects $null. Otherwise expects the script block again.