### PR TITLE
Fruit for Vegetables

### DIFF
--- a/PSKoans/Koans/Foundations/AboutHashtables.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutHashtables.Koans.ps1
@@ -128,11 +128,11 @@ Describe 'Hashtables' {
                 # Enter keys and values in this table to make the below tests pass
             }
 
-            $Hashtable.ContainsKey('Apples') | Should -BeTrue
+            $Hashtable.ContainsKey('Carrots') | Should -BeTrue
             $Hashtable.ContainsValue('Fruit') | Should -BeTrue
 
             $Hashtable['Oranges'] | Should -Be 'Fruit'
-            $Hashtable['Apples'] | Should -Not -Be $Hashtable['Oranges']
+            $Hashtable['Carrots'] | Should -Not -Be $Hashtable['Oranges']
         }
 
         It 'will implicitly convert keys and lookup values' {


### PR DESCRIPTION
Then Apples don't have to be not-fruit.