### PR TITLE
Remove `rake` aliases and mentions to it in the prompts.

### DIFF
--- a/PSKoans/PSKoans.psd1
+++ b/PSKoans/PSKoans.psd1
@@ -83,7 +83,7 @@
     VariablesToExport     = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport       = @('Rake','Invoke-PSKoans','Test-Koans','Get-Enlightenment','__','FILL_ME_IN','Clear-Path')
+    AliasesToExport       = @('Invoke-PSKoans','Test-Koans','Get-Enlightenment','__','FILL_ME_IN','Clear-Path')
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()

--- a/PSKoans/Private/Write-MeditationPrompt.ps1
+++ b/PSKoans/Private/Write-MeditationPrompt.ps1
@@ -95,7 +95,7 @@ $Meditation
 "@
         OpenFolder     = @"
 
-You may run 'rake -Meditate' to begin your meditation.
+You may run 'Measure-Karma -Meditate' to begin your meditation.
 
 "@
         Completed      = @"

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -34,7 +34,7 @@ function Measure-Karma {
         Module: PSKoans
 	#>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Default")]
-    [Alias('Rake', 'Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate','Clear-Path')]
+    [Alias('Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate','Clear-Path')]
     param(
         [Parameter(Mandatory, ParameterSetName = "OpenFolder")]
         [Alias('Koans', 'Meditate')]


### PR DESCRIPTION
`rake` is a Ruby build tool and this module should not inadvertently mask it by using an alias of the same name.