### PR TITLE
Updated Switch Koans -- wildcard

### DIFF
--- a/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
@@ -195,9 +195,12 @@ Describe 'Switch' {
             $Condition = __
             # ... but only if you ask nicely, that is!
             $Result = switch -Wildcard ($Condition) {
-                # Wildcarded switches work with ? for single character and * for multiple characters
+                # Wildcarded switches work with * for multiple characters
                 'Harm*' {
-                    $_ -replace '(.)', '$1,a,'
+                    'Safe'
+                }
+                'Clarity' {
+                    'Vision'
                 }
             }
 


### PR DESCRIPTION
To address issue #66 dropped the regex and added a second match condition. Removing the regex should make it clearer how the switch statement is being evaluated.