### PR TITLE
Batch: Issue fix

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -35,7 +35,6 @@ Describe 'Alias Provider' {
         It 'can be queried with generic provider cmdlets' {
             $Aliases = Get-ChildItem 'Alias:'
 
-            $Aliases.Count | Should -Be __
             $Aliases.Name[0] | Should -Be __
             $Aliases.Definition[0] | Should -Be __
         }
@@ -48,10 +47,13 @@ Describe 'Alias Provider' {
         }
 
         It 'can create aliases too!' {
+            $Aliases.Count | Should -Be __
+
             New-Item -Path 'Alias:\grok' -Value 'Get-Item' -ErrorAction SilentlyContinue
             $File = grok '__' -ErrorAction SilentlyContinue
 
             $File | Should -BeOfType 'System.IO.FileInfo'
+            $Aliases.Count | Should -Be __
         }
     }
 

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -123,7 +123,7 @@ Describe 'Environment Provider' {
 }
 
 Describe 'FileSystem Provider' {
-    $Path = $home | Join-Path -ChildPath 'File001.tmp'
+    $Path = 'TestDrive:' | Join-Path -ChildPath 'File001.tmp'
     if (-not (Test-Path $Path)) {
         New-Item -Path $Path > $null
 

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -54,6 +54,8 @@ Describe 'Alias Provider' {
 
             $File | Should -BeOfType 'System.IO.FileInfo'
             $Aliases.Count | Should -Be __
+
+            Remove-Item -Path 'Alias:\grok'
         }
     }
 

--- a/PSKoans/Koans/Foundations/AboutFunctionsAndScriptBlocks.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutFunctionsAndScriptBlocks.Koans.ps1
@@ -116,7 +116,8 @@ Describe 'Script Block' {
         # Sometimes, you just want to watch things burn, and the console to stream red errors.
         $Script2 = {
             # Currently, this will just output the script block as an object
-            $Script # Try appending .Invoke() to this line to cause the original block to be executed
+            # Try appending .Invoke() to the following line to cause the original block to be executed
+            $Script
         }
         $Script | Should -Throw
         $Script2 | Should -Throw

--- a/PSKoans/Koans/Foundations/AboutFunctionsAndScriptBlocks.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutFunctionsAndScriptBlocks.Koans.ps1
@@ -70,7 +70,10 @@ Describe 'Functions' {
         Add-Numbers 1 7 | Should -Be __
         Add-Numbers __ 15 | Should -Be 31
 
-        # Values can be passed to specified parameters
+        <#
+            Values can be passed to specified parameters; these values will be assigned to
+            the variables of the same name defined at the head of the function.
+        #>
         Add-Numbers -Number2 8 -Number1 12 | Should -Be 20
     }
 
@@ -78,7 +81,9 @@ Describe 'Functions' {
         function Measure-String {
             <#
                 Declaring parameters in this way allows for more advanced techniques,
-                which will be covered in AboutAdvancedFunctions
+                which will be covered in AboutAdvancedFunctions. It works similarly
+                to the simpler technique, values can be passed in the same way by
+                position or name.
             #>
             param(
                 $InputString

--- a/PSKoans/Koans/Foundations/AboutOrderOfOperations.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutOrderOfOperations.Koans.ps1
@@ -40,7 +40,7 @@ Describe "Order of Operations" {
 
     It "otherwise follows standard mathematical rules" {
         # Although PowerShell doesn't have a native exponentiation operator,
-        # we can use [Math]::Pow($a, $b)
+        # we do have [Math]::Pow($base, $power)
         3 + 4 / [Math]::Pow(2, 3) | Should -Be __
     }
 }


### PR DESCRIPTION
Fix #86 - move alias count check to more apropos location, remove alias before exiting the `It` block
Fix #85 - improve comments re: `[Math]::Pow()` usage
Fix #84 - improve comments
Fix #79 - use TestDrive: instead of live file system, to prevent failing earlier tests