### PR TITLE
Permit Specifying and Listing Topics for Measure-Karma

### DIFF
--- a/PSKoans/Private/Write-MeditationPrompt.ps1
+++ b/PSKoans/Private/Write-MeditationPrompt.ps1
@@ -51,7 +51,11 @@
 
         [Parameter(Mandatory, ParameterSetName = 'Enlightened')]
         [switch]
-        $Complete
+        $Complete,
+
+        [Parameter()]
+        [string[]]
+        $Topic
     )
 
     $Red = @{ForegroundColor = "Red"}
@@ -93,6 +97,13 @@ $Meditation
     Your path thus far:
 
 "@
+        WisdomTopic    = @"
+
+    $($Koan -replace "`n","`n    ")
+
+    Your path thus far in topics $($Topic -join ', '):
+
+"@
         OpenFolder     = @"
 
 You may run 'Measure-Karma -Meditate' to begin your meditation.
@@ -100,6 +111,14 @@ You may run 'Measure-Karma -Meditate' to begin your meditation.
 "@
         Completed      = @"
     Congratulations! You have taken the first steps towards enlightenment.
+
+    You cast your gaze back upon the path that you have walked:
+
+"@
+        CompletedTopic = @"
+    Congratulations! You have taken the first steps towards enlightenment.
+
+    You have completed: $($Topic -join ', ')
 
     You cast your gaze back upon the path that you have walked:
 
@@ -126,7 +145,13 @@ You may run 'Measure-Karma -Meditate' to begin your meditation.
             Write-Host @Blue $Prompts['Meditate']
             Write-Host @Red $Prompts['Subject']
             Start-Sleep @SleepTime
-            Write-Host @Blue $Prompts['Wisdom']
+
+            if ($PSBoundParameters.ContainsKey('Topic')) {
+                Write-Host @Blue $Prompts['WisdomTopic']
+            }
+            else {
+                Write-Host @Blue $Prompts['Wisdom']
+            }
 
             Write-Verbose 'Calculating progress...'
             $ProgressAmount = "$KoansPassed/$TotalKoans"
@@ -143,7 +168,12 @@ You may run 'Measure-Karma -Meditate' to begin your meditation.
             break
         }
         'Enlightened' {
-            Write-Host @Blue $Prompts['Completed']
+            if ($PSBoundParameters.ContainsKey('Topic')) {
+                Write-Host @Blue $Prompts['CompletedTopic']
+            }
+            else {
+                Write-Host @Blue $Prompts['Completed']
+            }
 
             $ProgressAmount = "$KoansPassed/$TotalKoans"
             [int]$ProgressWidth = $host.UI.RawUI.WindowSize.Width * 0.8 - ($ProgressAmount.Length + 4)
@@ -155,7 +185,10 @@ You may run 'Measure-Karma -Meditate' to begin your meditation.
                 $ProgressAmount
             ) | Write-Host @Blue
 
-            Write-Host @Blue $Prompts['BookSuggestion']
+            if (-not $PSBoundParameters.ContainsKey('Topic')) {
+                Write-Host @Blue $Prompts['BookSuggestion']
+            }
+
             break
         }
     }

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -17,7 +17,7 @@ function Measure-Karma {
 	.SYNOPSIS
         Reflect on your progress and check your answers.
     .DESCRIPTION
-        Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
+        Measure-Karma executes Pester against the koans to evaluate if you have made the necessary
         corrections for success.
     .PARAMETER Topic
         Execute koans only from the selected Topic(s).

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -21,7 +21,7 @@ function Measure-Karma {
         corrections for success.
     .PARAMETER Topic
         Execute koans only from the selected Topic(s).
-    .PARAMETER ListKoans
+    .PARAMETER ListTopics
         Output a complete list of available koan topics.
     .PARAMETER Contemplate
         Opens your local koan folder.
@@ -57,8 +57,9 @@ function Measure-Karma {
         $Topic,
 
         [Parameter(Mandatory, ParameterSetName = 'ListKoans')]
+        [Alias('ListKoans')]
         [switch]
-        $ListKoans,
+        $ListTopics,
 
         [Parameter(Mandatory, ParameterSetName = "OpenFolder")]
         [Alias('Meditate')]

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -1,10 +1,28 @@
-﻿function Measure-Karma {
+﻿using namespace System.Management.Automation
+
+class ValidKoanValues : IValidateSetValuesGenerator {
+    [string[]] GetValidValues() {
+        $Values = Get-ChildItem -Path $env:PSKoans_Folder -Recurse -Filter '*.Koans.ps1' |
+            Sort-Object -Property BaseName |
+            ForEach-Object {
+            $_.BaseName -replace '\.Koans$'
+        }
+
+        return $Values
+    }
+}
+
+function Measure-Karma {
     <#
 	.SYNOPSIS
         Reflect on your progress and check your answers.
     .DESCRIPTION
         Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
         corrections for success.
+    .PARAMETER Topic
+        Execute koans only from the selected Topic(s).
+    .PARAMETER ListKoans
+        Output a complete list of available koan topics.
     .PARAMETER Contemplate
         Opens your local koan folder.
 	.PARAMETER Reset
@@ -30,10 +48,20 @@
         Module: PSKoans
 	#>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Default")]
-    [Alias('Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate','Clear-Path')]
+    [Alias('Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate', 'Clear-Path')]
     param(
+        [Parameter(ParameterSetName = 'Default')]
+        [Alias('Koan', 'File')]
+        [ValidateSet([ValidKoanValues])]
+        [string[]]
+        $Topic,
+
+        [Parameter(Mandatory, ParameterSetName = 'ListKoans')]
+        [switch]
+        $ListKoans,
+
         [Parameter(Mandatory, ParameterSetName = "OpenFolder")]
-        [Alias('Koans', 'Meditate')]
+        [Alias('Meditate')]
         [switch]
         $Contemplate,
 
@@ -42,11 +70,17 @@
         $Reset
     )
     switch ($PSCmdlet.ParameterSetName) {
-        "Reset" {
+        'ListKoans' {
+            Get-ChildItem -Path $env:PSKoans_Folder -Recurse -File -Filter '*.Koans.ps1' |
+                ForEach-Object {
+                    $_.BaseName -replace '\.Koans$'
+                }
+        }
+        'Reset' {
             Write-Verbose "Reinitializing koan directory"
             Initialize-KoanDirectory
         }
-        "OpenFolder" {
+        'OpenFolder' {
             Write-Verbose "Opening koans folder"
             if (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
                 Start-Process -FilePath 'code' -ArgumentList $env:PSKoans_Folder -NoNewWindow
@@ -61,12 +95,16 @@
             Write-MeditationPrompt -Greeting
 
             Write-Verbose 'Sorting koans...'
-            $SortedKoanList = Get-ChildItem "$env:PSKoans_Folder" -Recurse -Filter '*.Koans.ps1' |
+            $SortedKoanList = Get-ChildItem -Path $env:PSKoans_Folder -Recurse -Filter '*.Koans.ps1' |
+                Where-Object {
+                    -not $PSBoundParameters.ContainsKey('Topic') -or
+                    $_.BaseName -replace '\.Koans$' -in $Topic
+                } |
                 Get-Command {$_.FullName} |
                 Where-Object {$_.ScriptBlock.Attributes.TypeID -match 'KoanAttribute'} |
                 Sort-Object {
-                $_.ScriptBlock.Attributes.Where( {$_.TypeID -match 'KoanAttribute'}).Position
-            }
+                    $_.ScriptBlock.Attributes.Where( {$_.TypeID -match 'KoanAttribute'}).Position
+                }
 
             Write-Verbose 'Counting koans...'
             $TotalKoans = $SortedKoanList | Measure-Koan
@@ -85,7 +123,6 @@
             foreach ($KoanFile in $SortedKoanList.Path) {
                 Write-Verbose "Testing karma with file [$KoanFile]"
 
-                $GlobalScope = [PSModuleInfo]::new($true)
                 $PesterParams = @{
                     Script   = $KoanFile
                     PassThru = $true
@@ -99,7 +136,7 @@
 
                 Write-Verbose "Karma: $KoansPassed"
                 if ($PesterTests.FailedCount -gt 0) {
-                    Write-Verbose "Your karma has been damaged."
+                    Write-Verbose 'Your karma has been damaged.'
                     break
                 }
             }
@@ -117,6 +154,11 @@
                     KoansPassed  = $KoansPassed
                     TotalKoans   = $TotalKoans
                 }
+
+                if ($PSBoundParameters.ContainsKey('Topic')) {
+                    $Meditation.Add('Topic', $Topic)
+                }
+
                 Write-MeditationPrompt @Meditation
             }
             else {
@@ -125,6 +167,11 @@
                     KoansPassed = $KoansPassed
                     TotalKoans  = $PesterTestCount
                 }
+
+                if ($PSBoundParameters.ContainsKey('Topic')) {
+                    $Meditation.Add('Topic', $Topic)
+                }
+
                 Write-MeditationPrompt @Meditation
             }
         }

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -1,6 +1,6 @@
 ﻿using namespace System.Management.Automation
 
-class ValidKoanValues : IValidateSetValuesGenerator {
+class KoanTopics : IValidateSetValuesGenerator {
     [string[]] GetValidValues() {
         $Values = Get-ChildItem -Path $env:PSKoans_Folder -Recurse -Filter '*.Koans.ps1' |
             Sort-Object -Property BaseName |
@@ -52,7 +52,7 @@ function Measure-Karma {
     param(
         [Parameter(ParameterSetName = 'Default')]
         [Alias('Koan', 'File')]
-        [ValidateSet([ValidKoanValues])]
+        [ValidateSet([KoanTopics])]
         [string[]]
         $Topic,
 


### PR DESCRIPTION
* Adds `-ListTopics` parameter to `Measure-Koan` which outputs a list of available koan topics
* Adds `-Topic` parameter (`string[]`) that allows users to specify the koan topic(s) they wish to focus on
    * Values are autocompleted based on available koan files in `$env:PSKoans_Folder`

Resolves #99 
Resolves #100 
