### PR TITLE
Allow measure-karma -Contemplate to use code-insiders

### DIFF
--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -48,7 +48,7 @@
         }
         "OpenFolder" {
             Write-Verbose "Opening koans folder"
-            if ($env:PSKoans_EditorPreference = 'code-insiders') {
+            if ($env:PSKoans_EditorPreference -eq 'code-insiders') {
                 Start-Process -FilePath 'code-insiders' -ArgumentList $env:PSKoans_Folder -NoNewWindow
             }
             elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -49,7 +49,7 @@
         }
         "OpenFolder" {
             Write-Verbose "Opening koans folder"
-            if ($env:PSKoans_EditorPreference -eq 'code-insiders' -and Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) {
+            if ( $env:PSKoans_EditorPreference -eq 'code-insiders' -and (Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) ) {
                 Start-Process -FilePath 'code-insiders' -ArgumentList $env:PSKoans_Folder -NoNewWindow
             }
             elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -4,7 +4,7 @@
         Reflect on your progress and check your answers.
     .DESCRIPTION
         Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
-        corrections for success.
+        corrections for success. If you'd like to use VS Code Insiders, set $env:PSKoans_EditorPreference equal to "code-insiders".
     .PARAMETER Contemplate
         Opens your local koan folder.
 	.PARAMETER Reset
@@ -48,7 +48,10 @@
         }
         "OpenFolder" {
             Write-Verbose "Opening koans folder"
-            if (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
+            if ($env:PSKoans_EditorPreference = 'code-insiders') {
+                Start-Process -FilePath 'code-insiders' -ArgumentList $env:PSKoans_Folder -NoNewWindow
+            }
+            elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
                 Start-Process -FilePath 'code' -ArgumentList $env:PSKoans_Folder -NoNewWindow
             }
             else {

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -4,7 +4,8 @@
         Reflect on your progress and check your answers.
     .DESCRIPTION
         Get-Enlightenment executes Pester against the koans to evaluate if you have made the necessary
-        corrections for success. If you'd like to use VS Code Insiders, set $env:PSKoans_EditorPreference equal to "code-insiders".
+        corrections for success. If you'd like to use VS Code Insiders, set $env:PSKoans_EditorPreference 
+	equal to "code-insiders".
     .PARAMETER Contemplate
         Opens your local koan folder.
 	.PARAMETER Reset
@@ -48,7 +49,7 @@
         }
         "OpenFolder" {
             Write-Verbose "Opening koans folder"
-            if ($env:PSKoans_EditorPreference -eq 'code-insiders') {
+            if ($env:PSKoans_EditorPreference -eq 'code-insiders' -and Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) {
                 Start-Process -FilePath 'code-insiders' -ArgumentList $env:PSKoans_Folder -NoNewWindow
             }
             elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
Right now `Measure-Karma -Contemplate` uses VS Code if it's installed, and invokes the item (likely opening ISE) if it is not. This PR adds support for an env variable that would allow a user to choose the Insiders edition of VS Code if they prefer.