### PR TITLE
Remove unneeded wait periods

### DIFF
--- a/PSKoans/Private/Invoke-Koan.ps1
+++ b/PSKoans/Private/Invoke-Koan.ps1
@@ -74,11 +74,10 @@
             $Thread = [powershell]::Create()
             $Thread.AddScript($Script) > $null
             $Thread.AddArgument($PSBoundParameters) > $null
-            $Thread.RunspacePool = $RunspacePool
 
             $Status = $Thread.BeginInvoke()
 
-            while (-not $Status.IsCompleted) { Start-Sleep -Milliseconds 10 }
+            do { } until ($Status.IsCompleted)
 
             $Thread.EndInvoke($Status)
         }

--- a/PSKoans/Private/Show-MeditationPrompt.ps1
+++ b/PSKoans/Private/Show-MeditationPrompt.ps1
@@ -140,13 +140,13 @@ Type 'Measure-Karma -Meditate' when you are ready to begin your meditations.
         }
         'Meditation' {
             Write-Host @Red $Prompts['Describe']
-            Start-Sleep @SleepTime
+
             Write-Host @Blue $Prompts['TestFailed']
             Write-Host @Red $Prompts['Expectation']
-            Start-Sleep @SleepTime
+
             Write-Host @Blue $Prompts['Meditate']
             Write-Host @Red $Prompts['Subject']
-            Start-Sleep @SleepTime
+
             Write-Host @Blue $Prompts['Koan']
 
             if ($PSBoundParameters.ContainsKey('Topic')) {

--- a/Tests/Functions/Private/Show-MeditationPrompt.Tests.ps1
+++ b/Tests/Functions/Private/Show-MeditationPrompt.Tests.ps1
@@ -32,7 +32,6 @@ InModuleScope 'PSKoans' {
                 Show-MeditationPrompt @Meditation | Should -BeNullOrEmpty
 
                 Assert-MockCalled Write-Host -Times 8
-                Assert-MockCalled Start-Sleep -Times 3
             }
         }
 


### PR DESCRIPTION
* Removes `Start-Sleep` periods from `Show-MeditationPrompt`
* Removes small waiting period from `Invoke-Koan` so that it can return as soon as it detects the threaded job's completion.

/cc @Markekraus @thomasrayner 