### PR TITLE
Refactor Invoke-Koan

### DIFF
--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -74,7 +74,7 @@ Task 'Build' -Depends 'Test' {
 $Lines
 "@
     # Load the module, read the exported functions, update the psd1 FunctionsToExport
-    Set-ModuleFunctions
+    Set-ModuleFunction
 
     # Bump the module version if we didn't already
     try {

--- a/PSKoans/Private/Invoke-Koan.ps1
+++ b/PSKoans/Private/Invoke-Koan.ps1
@@ -1,71 +1,34 @@
 ﻿function Invoke-Koan {
     <#
-        .FORWARDHELPTARGETNAME Invoke-Pester
-        .FORWARDHELPCATEGORY Function
+    .SYNOPSIS
+        Safely invokes Pester on a koan file in a fresh scope where tests can be executed out of harm's way.
+
+    .DESCRIPTION
+        Creates a new instance of PowerShell to execute the Pester tests in. Requires a valid parameter-splat hashtable
+        for Invoke-Pester.
+
+    .PARAMETER ParameterSplat
+        Defines the hashtable that will be splatted into Invoke-Pester in the new PowerShell instance.
+
+    .EXAMPLE
+        Invoke-Koan @{ Script = '.\AboutArrays.Koans.ps1'; PassThru = $true; Show = 'None' }
+
+        Triggers Pester to assess the AboutArrays file in the current directory and pass back the complete tests object,
+        hiding the standard test results display.
     #>
-    [CmdletBinding(DefaultParameterSetName = 'Default')]
-    [OutputType([PSCustomObject])]
+
+    [CmdletBinding()]
+    [OutputType([PSObject])]
     param(
-        [Parameter(Position = 0)]
-        [Alias('Path', 'relative_path')]
-        [PSObject[]]
-        $Script,
-
-        [Parameter(Position = 1)]
-        [Alias('Name')]
-        [string[]]
-        $TestName,
-
-        [Parameter(Position = 2)]
-        [switch]
-        $EnableExit,
-
-        [Parameter(Position = 4)]
-        [Alias('Tags')]
-        [string[]]
-        $Tag,
-
-        [string[]]
-        $ExcludeTag,
-
-        [switch]
-        $PassThru,
-
-        [PSObject[]]
-        $CodeCoverage,
-
-        [string]
-        $CodeCoverageOutputFile,
-
-        [ValidateSet('JaCoCo')]
-        [string]
-        $CodeCoverageOutputFileFormat,
-
-        [switch]
-        $Strict,
-
-        [Parameter(ParameterSetName = 'NewOutputSet', Mandatory = $true)]
-        [string]
-        $OutputFile,
-
-        [Parameter(ParameterSetName = 'NewOutputSet')]
-        [ValidateSet('NUnitXml')]
-        [string]
-        $OutputFormat,
-
-        [switch]
-        $Quiet,
-
-        [PSObject]
-        $PesterOption,
-
-        [Pester.OutputTypes]
-        $Show
+        [Parameter(Position = 0, Mandatory)]
+        [Alias('Params')]
+        [hashtable]
+        $ParameterSplat
     )
     end {
         try {
             $Script = {
-                param($Params)
+                param( $Params )
 
                 . ([scriptblock]::Create('using module PSKoans'))
                 Invoke-Pester @Params
@@ -73,7 +36,7 @@
 
             $Thread = [powershell]::Create()
             $Thread.AddScript($Script) > $null
-            $Thread.AddArgument($PSBoundParameters) > $null
+            $Thread.AddArgument($ParameterSplat) > $null
 
             $Status = $Thread.BeginInvoke()
 

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -137,14 +137,12 @@
             foreach ($KoanFile in $SortedKoanList) {
                 Write-Verbose "Testing karma with file [$($KoanFile.Path)]"
 
-                $PesterParams = @{
+                # Execute in a fresh scope to prevent internal secrets being leaked
+                $PesterTests = Invoke-Koan @{
                     Script   = $KoanFile.Path
                     PassThru = $true
                     Show     = 'None'
                 }
-
-                # Execute in a fresh scope to prevent internal secrets being leaked
-                $PesterTests = Invoke-Koan -ParameterSplat $PesterParams
 
                 $KoansPassed += $PesterTests.PassedCount
 

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -144,7 +144,7 @@
                 }
 
                 # Execute in a fresh scope to prevent internal secrets being leaked
-                $PesterTests = Invoke-Koan @PesterParams
+                $PesterTests = Invoke-Koan -ParameterSplat $PesterParams
 
                 $KoansPassed += $PesterTests.PassedCount
 

--- a/Tests/Functions/Private/Invoke-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-Koan.Tests.ps1
@@ -12,11 +12,11 @@ InModuleScope 'PSKoans' {
         }
 
         It 'will produce output with -Passthru' {
-            Invoke-Koan @{ Script = ${global:Test File} -PassThru } | Should -Not -BeNullOrEmpty
+            Invoke-Koan @{ Script = ${global:Test File} } -PassThru | Should -Not -BeNullOrEmpty
         }
 
         It 'will correctly report test results' {
-            $Results = Invoke-Koan @{ Script = ${global:Test File} -PassThru }
+            $Results = Invoke-Koan @{ Script = ${global:Test File } } -PassThru
 
             $Results.TotalCount | Should -Be 2
             $Results.PassedCount | Should -Be 0
@@ -24,7 +24,7 @@ InModuleScope 'PSKoans' {
         }
 
         It 'reports only expected exception types' {
-            $Results = Invoke-Koan @{ Script = ${global:Test File} -PassThru }
+            $Results = Invoke-Koan @{ Script = ${global:Test File} } -PassThru
 
             $Results.TestResult.ErrorRecord.Exception |
                 ForEach-Object -MemberName GetType |

--- a/Tests/Functions/Private/Invoke-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-Koan.Tests.ps1
@@ -1,4 +1,4 @@
-﻿##Requires -Modules SKoans
+﻿#Requires -Modules SKoans
 
 ${global:Test File} = "$PSScriptRoot/ControlTests/Invoke-Koan.Control_Tests.ps1"
 
@@ -7,16 +7,16 @@ InModuleScope 'PSKoans' {
 
         It 'will not error out' {
             {
-                Invoke-Koan -Script ${global:Test File}
+                Invoke-Koan @{ Script = ${global:Test File} }
             } | Should -Not -Throw
         }
 
         It 'will produce output with -Passthru' {
-            Invoke-Koan -Script ${global:Test File} -PassThru | Should -Not -BeNullOrEmpty
+            Invoke-Koan @{ Script = ${global:Test File} -PassThru } | Should -Not -BeNullOrEmpty
         }
 
         It 'will correctly report test results' {
-            $Results = Invoke-Koan -Script ${global:Test File} -PassThru
+            $Results = Invoke-Koan @{ Script = ${global:Test File} -PassThru }
 
             $Results.TotalCount | Should -Be 2
             $Results.PassedCount | Should -Be 0
@@ -24,7 +24,7 @@ InModuleScope 'PSKoans' {
         }
 
         It 'reports only expected exception types' {
-            $Results = Invoke-Koan -Script ${global:Test File} -PassThru
+            $Results = Invoke-Koan @{ Script = ${global:Test File} -PassThru }
 
             $Results.TestResult.ErrorRecord.Exception |
                 ForEach-Object -MemberName GetType |

--- a/Tests/Functions/Private/Invoke-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-Koan.Tests.ps1
@@ -12,11 +12,11 @@ InModuleScope 'PSKoans' {
         }
 
         It 'will produce output with -Passthru' {
-            Invoke-Koan @{ Script = ${global:Test File} } -PassThru | Should -Not -BeNullOrEmpty
+            Invoke-Koan @{ Script = ${global:Test File}; PassThru = $true } | Should -Not -BeNullOrEmpty
         }
 
         It 'will correctly report test results' {
-            $Results = Invoke-Koan @{ Script = ${global:Test File } } -PassThru
+            $Results = Invoke-Koan @{ Script = ${global:Test File}; PassThru = $true }
 
             $Results.TotalCount | Should -Be 2
             $Results.PassedCount | Should -Be 0
@@ -24,7 +24,7 @@ InModuleScope 'PSKoans' {
         }
 
         It 'reports only expected exception types' {
-            $Results = Invoke-Koan @{ Script = ${global:Test File} } -PassThru
+            $Results = Invoke-Koan @{ Script = ${global:Test File}; PassThru = $true }
 
             $Results.TestResult.ErrorRecord.Exception |
                 ForEach-Object -MemberName GetType |

--- a/Tests/Functions/Private/Invoke-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-Koan.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules SKoans
+﻿#Requires -Modules PSKoans
 
 ${global:Test File} = "$PSScriptRoot/ControlTests/Invoke-Koan.Control_Tests.ps1"
 


### PR DESCRIPTION
* Remove extraneous parameters & replace them with a single hashtable parameter to be splatted.
* Update calls to invoke-Koan in Measure-Karma and in tests.
* Fix module build issue caused by nonexported aliases from BuildHelpers module

It doesn't really need to declare that many parameters. It's only passing in a hashtable to be splatted anyway.

Any errors that occur can come from parameter binding on `Invoke-Pester` when it's called, we're not really saving anything by re-declaring those parameters. 😄 