### PR TITLE
Style: Use cleaner form for type detection switch

### DIFF
--- a/PSKoans/DummyTypes.ps1
+++ b/PSKoans/DummyTypes.ps1
@@ -1,10 +1,10 @@
 # Only attempt to load dummy types if they're not already present in the session
 
-switch ($true) {
-    { -not ('FillerType' -as [type]) } {
+switch ($null) {
+    ('FillerType' -as [type]) {
         class FillerType {}
     }
-    { -not ('__' -as [type]) } {
+    ('__' -as [type]) {
         class __ : FillerType {}
     }
 }


### PR DESCRIPTION
Took a bit of experimentation before I realised this was still valid syntax in the switch. 😉 