### PR TITLE
Update Measure-Karma to correctly open paths with spaces

### DIFF
--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -85,10 +85,10 @@
         'OpenFolder' {
             Write-Verbose "Opening koans folder"
             if ( $env:PSKoans_EditorPreference -eq 'code-insiders' -and (Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) ) {
-                Start-Process -FilePath 'code-insiders' -ArgumentList (Get-PSKoanLocation) -NoNewWindow
+                Start-Process -FilePath 'code-insiders' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
             }
             elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
-                Start-Process -FilePath 'code' -ArgumentList (Get-PSKoanLocation) -NoNewWindow
+                Start-Process -FilePath 'code' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
             }
             else {
                 Get-PSKoanLocation | Invoke-Item

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -85,10 +85,20 @@
         'OpenFolder' {
             Write-Verbose "Opening koans folder"
             if ( $env:PSKoans_EditorPreference -eq 'code-insiders' -and (Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) ) {
-                Start-Process -FilePath 'code-insiders' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
+                $VSCodeSplat = @{
+                    FilePath     = 'code-insiders'
+                    ArgumentList = '"{0}"' -f (Get-PSKoanLocation)
+                    NoNewWindow  = $true
+                }
+                Start-Process @VSCodeSplat 
             }
             elseif (Get-Command -Name 'code' -ErrorAction SilentlyContinue) {
-                Start-Process -FilePath 'code' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
+                $VSCodeSplat = @{
+                    FilePath     = 'code'
+                    ArgumentList = '"{0}"' -f (Get-PSKoanLocation)
+                    NoNewWindow  = $true
+                }
+                Start-Process @VSCodeSplat
             }
             else {
                 Get-PSKoanLocation | Invoke-Item

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -87,7 +87,7 @@
             if ( $env:PSKoans_EditorPreference -eq 'code-insiders' -and (Get-Command -Name 'code-insiders' -ErrorAction SilentlyContinue) ) {
                 Start-Process -FilePath 'code-insiders' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
             }
-            elseif (Get-Command -Name 'Code' -ErrorAction SilentlyContinue) {
+            elseif (Get-Command -Name 'code' -ErrorAction SilentlyContinue) {
                 Start-Process -FilePath 'code' -ArgumentList "`"$(Get-PSKoanLocation)`"" -NoNewWindow
             }
             else {


### PR DESCRIPTION
I have a path that has a space in it and running `Measure-Karma -Meditate` would open my editor incorrectly.  This update should allow Measure-Karma to open folders with spaces correctly.