### PR TITLE
Update AboutStrings to work cross-platform

### DIFF
--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -52,7 +52,7 @@ Describe 'Strings' {
 
         It 'handles other ways of doing the same thing' {
             # Strings can handle entire subexpressions being inserted as well!
-            $String = "Your default profile exists?: $(Test-Path $PROFILE)"
+            $String = "Your home folder is: $(Get-Item $HOME)"
             '__' | Should -Be $String
         }
 

--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -47,8 +47,7 @@ Describe 'Strings' {
         }
 
         It 'can do a simple expansion' {
-            $Windows = Get-Item 'C:\Windows' | Select-Object -ExpandProperty FullName
-            '__' | Should -Be "The windows directory is located here: $Windows"
+            '__' | Should -Be "Your working directory is located here: $pwd"
         }
 
         It 'handles other ways of doing the same thing' {

--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -47,12 +47,12 @@ Describe 'Strings' {
         }
 
         It 'can do a simple expansion' {
-            '__' | Should -Be "Your working directory is located here: $pwd"
+            '__' | Should -Be "Your home directory is located here: $HOME"
         }
 
         It 'handles other ways of doing the same thing' {
             # Strings can handle entire subexpressions being inserted as well!
-            $String = "The windows directory is located at $(Get-Item 'C:\Windows')"
+            $String = "Your default profile exists?: $(Test-Path $PROFILE)"
             '__' | Should -Be $String
         }
 


### PR DESCRIPTION
Fixes #137

Since the idea is to just show simple variable expansion I thought it would be easiest to just use `$pwd` instead of creating a new variable.