### PR TITLE
Make Clear-Host optional for Measure-Karma

### DIFF
--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -68,7 +68,12 @@
 
         [Parameter(Mandatory, ParameterSetName = "Reset")]
         [switch]
-        $Reset
+        $Reset,
+
+        [Parameter()]
+        [Alias()]
+        [switch]
+        $ClearScreen
     )
     switch ($PSCmdlet.ParameterSetName) {
         'ListKoans' {
@@ -90,7 +95,7 @@
                     ArgumentList = '"{0}"' -f (Get-PSKoanLocation)
                     NoNewWindow  = $true
                 }
-                Start-Process @VSCodeSplat 
+                Start-Process @VSCodeSplat
             }
             elseif (Get-Command -Name 'code' -ErrorAction SilentlyContinue) {
                 $VSCodeSplat = @{
@@ -105,7 +110,9 @@
             }
         }
         "Default" {
-            Clear-Host
+            if ($ClearScreen) {
+                Clear-Host
+            }
 
             Show-MeditationPrompt -Greeting
 

--- a/Tests/Functions/Public/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Measure-Karma.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Measure-Karma' {
             }
 
             It 'should not produce output' {
-                Measure-Karma | Should -Be $null
+                Measure-Karma -ClearScreen | Should -Be $null
             }
 
             It 'should clear the screen' {
@@ -81,7 +81,6 @@ Describe 'Measure-Karma' {
             }
 
             It 'should display only the greeting prompt' {
-                Assert-MockCalled Clear-Host
                 Assert-MockCalled Show-MeditationPrompt -Times 1
             }
 

--- a/Tests/Functions/Public/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Measure-Karma.Tests.ps1
@@ -20,6 +20,35 @@ Describe 'Measure-Karma' {
                 Measure-Karma | Should -Be $null
             }
 
+            It 'should write the meditation prompts' {
+                Assert-MockCalled Show-MeditationPrompt -Times 2
+            }
+
+            It 'should Invoke-Pester on each of the koans' {
+                $ValidKoans = Get-PSKoanLocation | Get-ChildItem -Recurse -Filter '*.Koans.ps1' |
+                    Get-Command {$_.FullName} |
+                    Where-Object {$_.ScriptBlock.Attributes.TypeID -match 'Koan'}
+
+                Assert-MockCalled Invoke-Koan -Times ($ValidKoans.Count)
+            }
+        }
+
+        Context 'With -ClearScreen Switch' {
+            BeforeAll {
+                Mock Clear-Host {}
+                Mock Show-MeditationPrompt -ModuleName 'PSKoans' {}
+                Mock Invoke-Koan -ModuleName 'PSKoans' {}
+
+                $TestLocation = 'TestDrive:{0}PSKoans' -f [System.IO.Path]::DirectorySeparatorChar
+                Set-PSKoanLocation -Path $TestLocation
+
+                Initialize-KoanDirectory -Confirm:$false
+            }
+
+            It 'should not produce output' {
+                Measure-Karma | Should -Be $null
+            }
+
             It 'should clear the screen' {
                 Assert-MockCalled Clear-Host -Times 1
             }


### PR DESCRIPTION
Fixes #139 

* Adds `-ClearScreen` switch to `Measure-Karma` to trigger `Clear-Host`.

Users can set `$PSDefaultParameterValues['Measure-Karma:ClearScreen'] = $true` if they would like this to be their default.