### PR TITLE
Improve behaviour of [Blank] & Small Refactoring

### DIFF
--- a/PSKoans/Classes/Blank.ps1
+++ b/PSKoans/Classes/Blank.ps1
@@ -2,8 +2,20 @@ class Blank {
     [string] ToString() {
         return $null
     }
-    
-    [bool] op_Equals([object] $other) {
+
+    static [bool] op_Equality([Blank] $self, [object] $other) {
+        return $false
+    }
+
+    static [bool] op_Inequality([Blank] $self, [object] $other) {
+        return $true
+    }
+
+    static [bool] op_Explicit([Blank] $Instance) {
+        return $false
+    }
+
+    static [bool] op_Implicit([Blank] $Instance) {
         return $false
     }
 }

--- a/PSKoans/Classes/Blank.ps1
+++ b/PSKoans/Classes/Blank.ps1
@@ -16,10 +16,10 @@ class Blank {
     }
 
     static [bool] op_Explicit([Blank] $Instance) {
-        return $null
+        return $false
     }
 
     static [bool] op_Implicit([Blank] $Instance) {
-        return $null
+        return $false
     }
 }

--- a/PSKoans/Classes/Blank.ps1
+++ b/PSKoans/Classes/Blank.ps1
@@ -3,6 +3,10 @@ class Blank {
         return $null
     }
 
+    [bool] Equals([object] $other) {
+        return $false
+    }
+
     static [bool] op_Equality([Blank] $self, [object] $other) {
         return $false
     }
@@ -12,10 +16,10 @@ class Blank {
     }
 
     static [bool] op_Explicit([Blank] $Instance) {
-        return $false
+        return $null
     }
 
     static [bool] op_Implicit([Blank] $Instance) {
-        return $false
+        return $null
     }
 }

--- a/PSKoans/Koans/Foundations/AboutAssertions.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutAssertions.Koans.ps1
@@ -24,7 +24,7 @@ Describe 'Equality' {
 
     It 'is a simple comparison' {
         # Some truths are absolute.
-        __ | Should -Be $true
+        '__' | Should -Be 'True!'
     }
 
     It 'expects you to fill in values' {

--- a/Tests/KoanValidation.Tests.ps1
+++ b/Tests/KoanValidation.Tests.ps1
@@ -6,15 +6,14 @@ Describe "Koan Assessment" {
     $Scripts = Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.Koans.ps1'
 
     # TestCases are splatted to the script so we need hashtables
-    $TestCases = $Scripts | ForEach-Object { @{File = $_} }
+    $TestCases = $Scripts | ForEach-Object { @{File = $_ } }
     It "<File> koans should be valid powershell" -TestCases $TestCases {
         param($File)
 
         $File.FullName | Should -Exist
 
-        $FileContents = Get-Content -Path $File.FullName -ErrorAction Stop
-        $Errors = $null
-        [System.Management.Automation.PSParser]::Tokenize($FileContents, [ref]$Errors) > $null
+        $Errors = $Tokens = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$Tokens, [ref]$Errors) > $null
         $Errors.Count | Should -Be 0
     }
 }


### PR DESCRIPTION
The following assertions _cannot be failed_ by any reference types, due to how PowerShell's comparison and boolean conversion behaves.

```ps
[Blank]::new() | Should -Be $true
[Blank]::new() | Should -BeTrue
```

As a workaround, the initial assertion in `AboutAssertions` has been modified to actually start as failing. Also, an `Equals()` instance method was added in order to properly allow the following behaviour:

```ps
$a = [Blank]::new()
$a -eq $a
# False
```