### PR TITLE
Fix topic progress when topic file is completed.

### DIFF
--- a/PSKoans/Private/Show-MeditationPrompt.ps1
+++ b/PSKoans/Private/Show-MeditationPrompt.ps1
@@ -160,7 +160,7 @@ function Show-MeditationPrompt {
                 break
             }
             'Enlightened' {
-                if ($PSBoundParameters.ContainsKey('Topic')) {
+                if ($PSBoundParameters.ContainsKey('RequestedTopic')) {
                     Write-Host @Blue ($script:MeditationPrompts['CompletedTopic'] -f ($RequestedTopic -join ', '))
                 }
                 else {
@@ -178,7 +178,7 @@ function Show-MeditationPrompt {
                 )
                 Write-Host $ProgressBar @Blue
 
-                if (-not $PSBoundParameters.ContainsKey('Topic')) {
+                if (-not $PSBoundParameters.ContainsKey('RequestedTopic')) {
                     Write-Host @Blue $script:MeditationPrompts['BookSuggestion']
                 }
 

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -161,21 +161,17 @@
                         Total     = $PesterTests.TotalCount
                     }
                 }
-
-                if ($PSBoundParameters.ContainsKey('Topic')) {
-                    $Meditation.Add('RequestedTopic', $Topic)
-                }
             }
             else {
                 $Meditation = @{
                     Complete    = $true
                     KoansPassed = $KoansPassed
-                    TotalKoans  = $PesterTestCount
+                    TotalKoans  = $PesterTests.TotalCount
                 }
+            }
 
-                if ($PSBoundParameters.ContainsKey('Topic')) {
-                    $Meditation.Add('RequestedTopic', $Topic)
-                }
+            if ($PSBoundParameters.ContainsKey('Topic')) {
+                $Meditation.Add('RequestedTopic', $Topic)
             }
 
             Show-MeditationPrompt @Meditation


### PR DESCRIPTION
# PR Summary

Fixes #162 

This issue had two problems causing it:

1. Measure-Karma was calling Show-MeditationPrompt and supplying a value from a variable that didn't exist. I assume it was something I'd been using previously and didn't remember to update the reference when it was changed.
2. Show-MeditationPrompt was checking if a topic was provided with `$PSBoundParameters.ContainsKey('Topic')` when it should have been looking for _`'RequestedTopic'`_ instead.

## Changes

- Update reference to pester test count to reference the proper value in Measure-Karma.
- Update parameter check in Show-MeditationPrompt to look for `RequestedTopic` parameter which actually exists.