### PR TITLE
Add -Detailed parameter for Measure-Karma

### DIFF
--- a/PSKoans/Data/Show-MeditationPrompt.Data.psd1
+++ b/PSKoans/Data/Show-MeditationPrompt.Data.psd1
@@ -5,6 +5,9 @@
     Please wait a moment while we examine your karma...
 
 "@
+        DetailEntry    = @"
+{0} It {1}
+"@
         Describe       = @"
 Describing '{0}' has damaged your karma.
 "@
@@ -21,8 +24,8 @@ Describing '{0}' has damaged your karma.
 
 "@
         Subject        = @"
-[It] {0}
-{1}
+{0} It {1}
+{2}
 "@
         Koan           = @"
 

--- a/PSKoans/Private/Show-MeditationPrompt.ps1
+++ b/PSKoans/Private/Show-MeditationPrompt.ps1
@@ -82,12 +82,18 @@ function Show-MeditationPrompt {
 
         [Parameter()]
         [string[]]
-        $RequestedTopic
+        $RequestedTopic,
+
+        [Parameter()]
+        [PSObject[]]
+        $Results
     )
     begin {
         $Red = @{ForegroundColor = 'Red' }
         $Blue = @{ForegroundColor = 'Cyan' }
         $White = @{ForegroundColor = 'Yellow' }
+        $Green = @{ForegroundColor = 'Green' }
+
         $Koan = (Get-Random -InputObject $script:MeditationStrings) -replace '^|\r?(\n)', ('$1    {0} ' -f [char]0x258c)
         $TopicList = ($RequestedTopic -join "`n        - ")
 
@@ -108,7 +114,7 @@ function Show-MeditationPrompt {
                 Write-Host @Red $Expectation
 
                 Write-Host @Blue $script:MeditationPrompts['Meditate']
-                Write-Host @Red ($script:MeditationPrompts['Subject'] -f $ItName, $Meditation)
+                Write-Host @Red ($script:MeditationPrompts['Subject'] -f [char]0xd7, $ItName, $Meditation)
 
                 Write-Host @White ($script:MeditationPrompts['Koan'] -f $Koan)
 
@@ -135,7 +141,7 @@ function Show-MeditationPrompt {
                     [int] $PortionDone = ($CurrentTopic['Completed'] / $CurrentTopic['Total']) * $TopicProgressWidth
 
                     $ProgressBar = " [{3}]: [{0}{1}] {2}" -f @(
-                        "$([char]0x25b0)" * $PortionDone
+                        "$([char]0x25a0)" * $PortionDone
                         "$([char]0x2015)" * ($TopicProgressWidth - $PortionDone)
                         $TopicProgressAmount
                         $CurrentTopic['Name']
@@ -143,6 +149,21 @@ function Show-MeditationPrompt {
                     Write-Host $ProgressBar @Blue
                 }
                 #endregion TopicProgressBar
+                Write-Host
+
+                if ($PSBoundParameters.ContainsKey('Results')) {
+                    foreach ($KoanResult in $Results) {
+                        $Params = @{
+                            Object = $script:MeditationPrompts['DetailEntry'] -f @(
+                                if ($KoanResult.Passed) { [char]0x25b8 } else { [char]0xd7 }
+                                $KoanResult.Name
+                            )
+                        }
+                        $Params += if ($KoanResult.Passed) { $Green } else { $Red }
+                        Write-Host @Params
+                    }
+                }
+
                 Write-Host
                 #region TotalProgressBar
                 [int] $PortionDone = ($KoansPassed / $TotalKoans) * $ProgressWidth

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -1,5 +1,5 @@
 ﻿function Measure-Karma {
-    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Default",
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Default',
         HelpUri = 'https://github.com/vexx32/PSKoans/tree/master/docs/Measure-Karma.md')]
     [OutputType([void])]
     [Alias('Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate', 'Clear-Path')]
@@ -42,7 +42,7 @@
         [switch]
         $ClearScreen,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'Default')]
         [Alias()]
         [switch]
         $Detailed

--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -40,7 +40,12 @@
         [Parameter()]
         [Alias()]
         [switch]
-        $ClearScreen
+        $ClearScreen,
+
+        [Parameter()]
+        [Alias()]
+        [switch]
+        $Detailed
     )
     switch ($PSCmdlet.ParameterSetName) {
         'ListKoans' {
@@ -143,12 +148,12 @@
                 }
             }
 
-            if ($PesterTests.FailedCount -gt 0) {
+            $Meditation = if ($PesterTests.FailedCount -gt 0) {
                 $NextKoanFailed = $PesterTests.TestResult |
                 Where-Object Result -eq 'Failed' |
                 Select-Object -First 1
 
-                $Meditation = @{
+                @{
                     DescribeName = $NextKoanFailed.Describe
                     Expectation  = $NextKoanFailed.ErrorRecord
                     ItName       = $NextKoanFailed.Name
@@ -163,11 +168,15 @@
                 }
             }
             else {
-                $Meditation = @{
+                @{
                     Complete    = $true
                     KoansPassed = $KoansPassed
                     TotalKoans  = $PesterTests.TotalCount
                 }
+            }
+
+            if ($Detailed) {
+                $Meditation.Add('Results', $PesterTests.TestResult)
             }
 
             if ($PSBoundParameters.ContainsKey('Topic')) {

--- a/PSKoans/en-us/PSKoans-help.xml
+++ b/PSKoans/en-us/PSKoans-help.xml
@@ -191,6 +191,66 @@ C:\Users\Timmy\PSKoans</dev:code>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Detailed</maml:name>
+          <maml:Description>
+            <maml:para>Adds a summarized view of the current topic file to the meditation prompt. The summary will contain a full list of all koans in the file, and indicate their current status.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Koan, File">
+          <maml:name>Topic</maml:name>
+          <maml:Description>
+            <maml:para>Execute koans only from the selected Topic(s). Regex patterns are permitted.</maml:para>
+            <maml:para>If combined with `-Reset`, the specified topics are reset to their initial states.</maml:para>
+          </maml:Description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:Description>
+            <maml:para>Prompts for confirmation before making any changes. Use with -Reset to always be prompted before any changes are made.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:Description>
+            <maml:para>When used with -Reset, displays what will be reset without actually resetting anything.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Measure-Karma</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ClearScreen</maml:name>
+          <maml:Description>
+            <maml:para>Clears the console host before displaying the meditation prompt.</maml:para>
+          </maml:Description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="ListKoans">
           <maml:name>ListTopics</maml:name>
           <maml:Description>
@@ -286,55 +346,6 @@ C:\Users\Timmy\PSKoans</dev:code>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
-      <command:syntaxItem>
-        <maml:name>Measure-Karma</maml:name>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
-          <maml:name>ClearScreen</maml:name>
-          <maml:Description>
-            <maml:para>Clears the console host before displaying the meditation prompt.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Koan, File">
-          <maml:name>Topic</maml:name>
-          <maml:Description>
-            <maml:para>Execute koans only from the selected Topic(s). Regex patterns are permitted.</maml:para>
-            <maml:para>If combined with `-Reset`, the specified topics are reset to their initial states.</maml:para>
-          </maml:Description>
-          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
-          <dev:type>
-            <maml:name>String[]</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>None</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
-          <maml:name>Confirm</maml:name>
-          <maml:Description>
-            <maml:para>Prompts for confirmation before making any changes. Use with -Reset to always be prompted before any changes are made.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
-          <maml:name>WhatIf</maml:name>
-          <maml:Description>
-            <maml:para>When used with -Reset, displays what will be reset without actually resetting anything.</maml:para>
-          </maml:Description>
-          <dev:type>
-            <maml:name>SwitchParameter</maml:name>
-            <maml:uri />
-          </dev:type>
-          <dev:defaultValue>False</dev:defaultValue>
-        </command:parameter>
-      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
@@ -354,6 +365,18 @@ C:\Users\Timmy\PSKoans</dev:code>
         <maml:Description>
           <maml:para>Opens your local koans library. If VS Code is installed, it will start VS Code in the folder. Otherwise, the folder is simply opened in a file explorer.</maml:para>
           <maml:para>If you have VS Code Insiders installed, you can set `$env:PSKoans_EditorPreference = "code-insiders"` to indicate VS Code Insiders should be opened instead.</maml:para>
+        </maml:Description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Detailed</maml:name>
+        <maml:Description>
+          <maml:para>Adds a summarized view of the current topic file to the meditation prompt. The summary will contain a full list of all koans in the file, and indicate their current status.</maml:para>
         </maml:Description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/docs/Measure-Karma.md
+++ b/docs/Measure-Karma.md
@@ -14,7 +14,7 @@ Reflect on your progress and check your answers.
 
 ### Default (Default)
 ```
-Measure-Karma [-Topic <String[]>] [-ClearScreen] [-WhatIf] [-Confirm] [<CommonParameters>]
+Measure-Karma [-Topic <String[]>] [-ClearScreen] [-Detailed] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Reset
@@ -95,6 +95,22 @@ Aliases: Meditate
 Required: True
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Detailed
+Adds a summarized view of the current topic file to the meditation prompt.
+The summary will contain a full list of all koans in the file, and indicate their current status.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
# PR Summary

Adds a new parameter to `Measure-Karma`: `-Detailed` (switch parameter).

## Details

When the `-Detailed` switch is provided, `Measure-Karma` adds a summary view of the file you're currently progressing through to the meditation prompt.

![image](https://user-images.githubusercontent.com/32407840/57167472-ea683f80-6dcb-11e9-87f3-2238edd1a7d2.png)

Some minor changes to the default prompt display were also made in order to give it some visual consistency with the new display.

Fixes #150