### PR TITLE
Fix divide by zero on some systems

### DIFF
--- a/PSKoans/Public/Measure-Karma.ps1
+++ b/PSKoans/Public/Measure-Karma.ps1
@@ -171,7 +171,7 @@
                 @{
                     Complete    = $true
                     KoansPassed = $KoansPassed
-                    TotalKoans  = $PesterTests.TotalCount
+                    TotalKoans  = $TotalKoans
                 }
             }
 

--- a/Tests/Functions/Public/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Measure-Karma.Tests.ps1
@@ -132,7 +132,7 @@ Describe 'Measure-Karma' {
 
             It 'should not divide by zero if all Koans are completed' {
                 $KoansCompletedTestLocation = 'TestDrive:{0}PSKoansCompletedTest' -f [System.IO.Path]::DirectorySeparatorChar
-                $TestFile = Join-Path -Path $TestLocation -ChildPath 'SingleTopicTest.Koans.Ps1'
+                $TestFile = Join-Path -Path $KoansCompletedTestLocation -ChildPath 'SingleTopicTest.Koans.Ps1'
 
                 New-Item $KoansCompletedTestLocation -ItemType Directory
                 New-Item $TestFile -ItemType File

--- a/Tests/Functions/Public/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Measure-Karma.Tests.ps1
@@ -131,10 +131,10 @@ Describe 'Measure-Karma' {
             }
 
             It 'should not divide by zero if all Koans are completed' {
-                $TestLocation = 'TestDrive:{0}PSKoansCompletedTest' -f [System.IO.Path]::DirectorySeparatorChar
+                $KoansCompletedTestLocation = 'TestDrive:{0}PSKoansCompletedTest' -f [System.IO.Path]::DirectorySeparatorChar
                 $TestFile = Join-Path -Path $TestLocation -ChildPath 'SingleTopicTest.Koans.Ps1'
 
-                New-Item $TestLocation -ItemType Directory
+                New-Item $KoansCompletedTestLocation -ItemType Directory
                 New-Item $TestFile -ItemType File
 
                 @'
@@ -149,9 +149,11 @@ Describe 'Koans Test' {
 }
 '@ | Set-Content $TestFile
 
-                Set-PSKoanLocation $TestLocation
+                Set-PSKoanLocation $KoansCompletedTestLocation
 
-                {Measure-Karma -Topic SingleTopicTest} | should -Not -Throw
+                {Measure-Karma -Topic SingleTopicTest} | Should -Not -Throw
+
+                Set-PSKoanLocation $TestLocation
             }
         }
 

--- a/Tests/Functions/Public/Measure-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Measure-Karma.Tests.ps1
@@ -129,6 +129,30 @@ Describe 'Measure-Karma' {
                 Measure-Karma -Topic $Topic
                 Assert-MockCalled Invoke-Koan -Times @($Topic).Count
             }
+
+            It 'should not divide by zero if all Koans are completed' {
+                $TestLocation = 'TestDrive:{0}PSKoansCompletedTest' -f [System.IO.Path]::DirectorySeparatorChar
+                $TestFile = Join-Path -Path $TestLocation -ChildPath 'SingleTopicTest.Koans.Ps1'
+
+                New-Item $TestLocation -ItemType Directory
+                New-Item $TestFile -ItemType File
+
+                @'
+using module PSKoans
+[Koan(Position = 1)]
+param()
+
+Describe 'Koans Test' {
+    It 'is easy to solve' {
+        $true | should -be $true
+    }
+}
+'@ | Set-Content $TestFile
+
+                Set-PSKoanLocation $TestLocation
+
+                {Measure-Karma -Topic SingleTopicTest} | should -Not -Throw
+            }
         }
 
         Context 'With -Reset Switch' {


### PR DESCRIPTION
Proposed fix #178 

﻿# PR Summary

Use `$TotalKoans` in stead of `$PesterTests.TotalCount` in both conditions. 

## Checklist

- ['x'] Pull Request has a meaningful title.
- ['x'] Summarised changes.
- ['x'] Pull Request is ready to merge & is not WIP.
- ['x'] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- ['NA'] Added documentation / opened issue to track adding documentation at a later date.
