### PR TITLE
Changed out-file parameter and updated Out-String koan

### DIFF
--- a/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
@@ -115,7 +115,7 @@ Context 'Out-* Cmdlets' {
             Out-String is a fantastic and simple way to turn complex objects into strings that look just
             like PowerShell's default console formatting.
         #>
-    
+
         It 'creates string representations of data' {
             #Create a hashtable that pipes into Out-String
             $String = @{ } | Out-String

--- a/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
@@ -81,7 +81,7 @@ Context 'Out-* Cmdlets' {
         It 'stores data in files' {
             $Path = 'TestDrive:\File.txt'
 
-            'Stored knowledge is of little value until it is used.' | Out-File -Path $Path -NoNewline
+            'Stored knowledge is of little value until it is used.' | Out-File -FilePath $Path -NoNewline
 
             '__' | Should -Be (Get-Content -Path $Path)
         }
@@ -115,23 +115,20 @@ Context 'Out-* Cmdlets' {
             Out-String is a fantastic and simple way to turn complex objects into strings that look just
             like PowerShell's default console formatting.
         #>
-
+    
         It 'creates string representations of data' {
-            $HomeFolder = Get-Item -Path $HOME
-
-            $HomeFolder | Should -Not -BeNullOrEmpty
-            $String = $HomeFolder | Out-String
-
-            # Fill in this here-string with the data you'd see in your console from calling Get-Item $HOME
+            #Create a hashtable that pipes into Out-String
+            $String = '__' | Out-String
+    
             @"
-
-
-    Directory: __
-
-
-Mode                LastWriteTime         Length Name
-----                -------------         ------ ----
-______         __________________                ____
+    
+    Name                           Value                                                                                                                                                                                         
+    ----                           -----                                                                                                                                                                                         
+    ColumnA                        Value1                                                                                                                                                                                        
+    ColumnB                        Value2                                                                                                                                                                                        
+    
+    
+    
 "@ | Should -Be $String
             # Mind the indentations; here-strings have to terminate at the very beginning of a line.
         }

--- a/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
@@ -118,17 +118,17 @@ Context 'Out-* Cmdlets' {
     
         It 'creates string representations of data' {
             #Create a hashtable that pipes into Out-String
-            $String = '__' | Out-String
+            $String = @{ } | Out-String
     
             @"
-    
-    Name                           Value                                                                                                                                                                                         
-    ----                           -----                                                                                                                                                                                         
-    ColumnA                        Value1                                                                                                                                                                                        
-    ColumnB                        Value2                                                                                                                                                                                        
-    
-    
-    
+
+Name                           Value                                                                                                                                                                                         
+----                           -----                                                                                                                                                                                         
+Color                          Blue
+Spectrum                       Ultraviolet                                                                                                                                                                                        
+
+
+
 "@ | Should -Be $String
             # Mind the indentations; here-strings have to terminate at the very beginning of a line.
         }


### PR DESCRIPTION
﻿# PR Summary
Resolves #197 

## Context

Out-String Koan is changed in its approach as carriage returns are "funny" and potentially confusing when trying to compare Get-Item output in a here string. The idea is if the here string is static, then the user only has to update what is piping into out-string. Since this koan is about out-string this feels appropriate.
## Changes

- Changed Out-File parameter from -Path to -FilePath to support Windows PowerShell 5.1 and earlier.
- Changed Out-String koan to not require here-string edits, instead requires updates to what is piped into Out-String.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
