### PR TITLE
Fixed typos, split ErrorRecord describe into two Contexts

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -160,7 +160,7 @@ Describe 'Types of Errors' {
             $ErrorRecord = Write-DetailedError 2>&1
 
             '__' | Should -Be $ErrorRecord.Exception.Message
-            '__,__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
+            '____,____' | Should -Be $ErrorRecord.FullyQualifiedErrorId
             '__' | Should -Be $ErrorRecord.TargetObject.Name
             '__' | Should -Be $ErrorRecord.ErrorDetails.RecommendedAction
         }

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -42,7 +42,7 @@ Describe 'ErrorRecord' {
         }
         It 'does continue to add Errors until the PowerShell session is closed' {
             Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction SilentlyContinue
-            '__' | Should -Be $Error.Count
+            __ | Should -Be $Error.Count
         }
         It 'is possible to surpress the error record all together' {
             Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction Ignore

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -49,7 +49,7 @@ Describe 'ErrorRecord' {
             '__' | Should -Be $Error.Count
         }
     }
-    Context "Error Assignments"{
+    Context 'Error Assignments' {
         BeforeAll {
             $ErrorRecord = try {
                 throw "A challenge to the sky!"

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -67,7 +67,7 @@ Describe 'ErrorRecord' {
         It 'always contains a reference to an Exception' {
             $ErrorRecord.Exception | Should -Not -BeNullOrEmpty
             $ErrorRecord.Exception -is [__] | Should -BeTrue
-            "__" | Should -Be $ErrorRecord.Exception.Message
+            '____' | Should -Be $ErrorRecord.Exception.Message
         }
 
         It 'can be assigned one of the preset categories' {

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -46,7 +46,7 @@ Describe 'ErrorRecord' {
         }
         It 'is possible to surpress the error record all together' {
             Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction Ignore
-            '__' | Should -Be $Error.Count
+            __ | Should -Be $Error.Count
         }
     }
     Context 'Error Assignments' {

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -27,16 +27,13 @@ Describe 'ErrorRecord' {
             $Error.Clear()
         }
         It 'sometimes has a reference to the object that caused the error' {
-            # But not always!
-            $Error[0].TargetObject | Should -BeNullOrEmpty
     
             # Non-terminating error behaviour can be adjusted with the -ErrorAction parameter.
             Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction SilentlyContinue
     
             <#
-                $Error is an automatic variable that contains a list of recent errors. $Error[0] is always the most
-                recent error. Even if an error is silenced with -ErrorAction SilentlyContinue, it is still recorded
-                in $Error.
+                $Error[0] is always the most recent error. Even if an error is silenced with
+                -ErrorAction SilentlyContinue, it is still recorded in $Error.
             #>
             '__' | Should -Be $Error[0].TargetObject
         }

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -86,7 +86,7 @@ Describe 'ErrorRecord' {
             # InvocationInfo is a quick snapshot of the surrounding environment when the error happened.
             __ | Should -Be $ErrorRecord.InvocationInfo.ScriptLineNumber
             __ | Should -Be $ErrorRecord.InvocationInfo.PipelineLength
-            '+ __' | Should -Be $ErrorRecord.InvocationInfo.PositionMessage
+            '+ ____' | Should -Be $ErrorRecord.InvocationInfo.PositionMessage
         }
     }
 }

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -18,60 +18,76 @@ param()
 #>
 
 Describe 'ErrorRecord' {
-    BeforeAll {
-        $ErrorRecord = try {
-            throw "A challenge to the sky!"
+    Context '$Error' {
+        BeforeAll{
+            <#
+                $Error is an automatic variable that contains a list of recent errors.
+                By calling $Error.Clear() we ensure past errors to not carry into our testing.
+            #>
+            $Error.Clear()
         }
-        catch {
-            $_
+        It 'sometimes has a reference to the object that caused the error' {
+            # But not always!
+            $Error[0].TargetObject | Should -BeNullOrEmpty
+    
+            # Non-terminating error behaviour can be adjusted with the -ErrorAction parameter.
+            Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction SilentlyContinue
+    
+            <#
+                $Error is an automatic variable that contains a list of recent errors. $Error[0] is always the most
+                recent error. Even if an error is silenced with -ErrorAction SilentlyContinue, it is still recorded
+                in $Error.
+            #>
+            '__' | Should -Be $Error[0].TargetObject
+        }
+        It 'does continue to add Errors until the PowerShell session is closed' {
+            Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction SilentlyContinue
+            '__' | Should -Be $Error.Count
+        }
+        It 'is possible to surpress the error record all together' {
+            Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction Ignore
+            '__' | Should -Be $Error.Count
         }
     }
+    Context "Error Assignments"{
+        BeforeAll {
+            $ErrorRecord = try {
+                throw "A challenge to the sky!"
+            }
+            catch {
+                $_
+            }
+        }
 
-    It 'is an ErrorRecord' {
-        # At times, even tautologies can make sense of what is, and is not.
-        $ErrorRecord -is [__] | Should -BeTrue
-    }
+        It 'is an ErrorRecord' {
+            # At times, even tautologies can make sense of what is, and is not.
+            $ErrorRecord -is [__] | Should -BeTrue
+        }
 
-    It 'always contains a reference to an Exception' {
-        $ErrorRecord.Exception | Should -Not -BeNullOrEmpty
-        $ErrorRecord.Exception -is [__] | Should -BeTrue
-        "__" | Should -Be $ErrorRecord.Exception.Message
-    }
+        It 'always contains a reference to an Exception' {
+            $ErrorRecord.Exception | Should -Not -BeNullOrEmpty
+            $ErrorRecord.Exception -is [__] | Should -BeTrue
+            "__" | Should -Be $ErrorRecord.Exception.Message
+        }
 
-    It 'sometimes has a reference to the object that caused the error' {
-        # But not always!
-        $ErrorRecord.TargetObject | Should -BeNullOrEmpty
+        It 'can be assigned one of the preset categories' {
+            '__' -as [System.Management.Automation.ErrorCategory] | Should -Be $ErrorRecord.CategoryInfo.Category
+        }
 
-        # Non-terminating error behaviour can be adjusted with the -ErrorAction parameter.
-        Get-Item -Path "TestDrive:\This_Shouldn't_Exist" -ErrorAction SilentlyContinue
+        It 'will usually specify an ErrorID' {
+            <#
+                These ID strings are generally used to identify the source of the error and help distinguish
+                between multiple similarly-typed errors.
+            #>
+            '__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
+        }
 
-        <#
-            $Error is an automatic variable that contains a list of recent errors. $Error[0] is always the most
-            recent error. Even if an error is silenced with -ErrorAction SilentlyContinue, it is still recorded
-            in $Error.
-
-            If you want to completely hide the error, you need to use -ErrorAction Ignore instead.
-        #>
-        '__' | Should -Be $Error[0].TargetObject
-    }
-
-    It 'can be assigned one of the preset categories' {
-        '__' -as [System.Management.Automation.ErrorCategory] | Should -Be $ErrorRecord.CategoryInfo.Category
-    }
-
-    It 'will usually specify an ErrorID' {
-        <#
-            These ID strings are generally used to identify the source of the error and help distinguish
-            between multiple similarly-typed errors.
-        #>
-        '__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
-    }
-
-    It 'contains an InvocationInfo reference' {
-        # InvocationInfo is a quick snapshot of the surrounding environment when the error happened.
-        __ | Should -Be $ErrorRecord.InvocationInfo.ScriptLineNumber
-        __ | Should -Be $ErrorRecord.InvocationInfo.PipelineLength
-        '+ __' | Should -Be $ErrorRecord.InvocationInfo.PositionMessage
+        It 'contains an InvocationInfo reference' {
+            # InvocationInfo is a quick snapshot of the surrounding environment when the error happened.
+            __ | Should -Be $ErrorRecord.InvocationInfo.ScriptLineNumber
+            __ | Should -Be $ErrorRecord.InvocationInfo.PipelineLength
+            '+ __' | Should -Be $ErrorRecord.InvocationInfo.PositionMessage
+        }
     }
 }
 
@@ -135,7 +151,7 @@ Describe 'Types of Errors' {
 
         It 'is emitted with the Write-Error cmdlet' {
             # The redirection operators can be used to more easily retrieve non-standard output, like errors
-            $ErrorRecord = Test-SimpleWriteError 2>&1
+            $ErrorRecord = Write-SimpleError 2>&1
 
             '__' | Should -Be $ErrorRecord.GetType().Name
         }
@@ -144,7 +160,7 @@ Describe 'Types of Errors' {
             $ErrorRecord = Write-DetailedError 2>&1
 
             '__' | Should -Be $ErrorRecord.Exception.Message
-            '__.__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
+            '__,__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
             '__' | Should -Be $ErrorRecord.TargetObject.Name
             '__' | Should -Be $ErrorRecord.ErrorDetails.RecommendedAction
         }
@@ -232,7 +248,7 @@ Describe 'Types of Errors' {
                 '__' | Should -Be $_.Exception.GetType().Name
             }
             catch {
-                Should -Fail -Because "This block shold only trigger if we don't handle the specific type separately."
+                Should -Fail -Because "This block should only trigger if we don't handle the specific type separately."
             }
         }
 
@@ -255,7 +271,7 @@ Describe 'Types of Errors' {
         It 'can be created by ThrowTerminatingError()' {
             # ThrowTerminatingError() can only be called from within an advanced function.
             function Invoke-TerminatingError {
-                [CmldetBinding()]
+                [CmdletBinding()]
                 param()
 
                 $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(

--- a/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutErrorHandling.Koans.ps1
@@ -79,7 +79,7 @@ Describe 'ErrorRecord' {
                 These ID strings are generally used to identify the source of the error and help distinguish
                 between multiple similarly-typed errors.
             #>
-            '__' | Should -Be $ErrorRecord.FullyQualifiedErrorId
+            '____' | Should -Be $ErrorRecord.FullyQualifiedErrorId
         }
 
         It 'contains an InvocationInfo reference' {


### PR DESCRIPTION
﻿# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->
Resolves #196 

## Context
Couple of minor typos corrected. Big change to the Describe ErrorRecord koan as there was a mix of $Error and $ErrorRecord. Splitting them into separate contexts seems a more intuitive approach for the user. 
<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

- Split the Describe ErrorRecord into Context $Error and Context ErrorAssignments.
- Fixed typo where Test-SimpleWriteError should be Write-SimpleError


<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarized changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
