### PR TITLE
Removed -Recurse, updated Regex Pattern, added help

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
@@ -28,20 +28,18 @@ Describe 'Splatting' {
             # Here are a few common ways a detailed command to find files in a folder might be written:
 
             # 1. Super long lines; hard to follow along with.
-            $LongLines = Get-ChildItem -Path $PSKoansFolder -Include '*.ps1' -Recurse -Depth 2
+            $LongLines = Get-ChildItem -Path $PSKoansFolder -Include '*.ps1' -Depth 2
 
             # 2. Escaping linebreaks; more readable, but very fragile and prone to errors
             $Escaping = Get-ChildItem `
                 -Path $PSKoansFolder `
                 -Include '*.ps1' `
-                -Recurse `
                 -Depth 2
 
             # 3. Splatting using a hashtable. Note the similarity to #2 and fill in missing values.
             $Parameters = @{
                 Path    = $PSKoansFolder
                 Include = '__'
-                Recurse = $true # Switches can be assigned a boolean value.
                 Depth   = __
             }
             $Splatted = Get-ChildItem @Parameters
@@ -49,10 +47,14 @@ Describe 'Splatting' {
                 All above approaches are equal in effect, but splatting is a much tidier and more
                 maintainable approach.
             #>
-            $Splatted | Should -Be $Escaping
-            $Escaping | Should -Be $LongLines
+            $Splatted.Count | Should -Be $Escaping.Count
+            $Splatted.Name | Should -Be $Escaping.Name
 
-            $LongLines | Should -Be $Splatted
+            $Escaping.Count | Should -Be $LongLines.Count
+            $Escaping.Name | Should -Be $LongLines.Name
+
+            $LongLines.Count | Should -Be $Splatted.Count
+            $LongLines.Name | Should -Be $Splatted.Name
         }
 
     }
@@ -65,6 +67,7 @@ Describe 'Splatting' {
             $Value = __
             if ($Value -eq 7) {
                 $Parameters.Add('File', $true)
+                $Parameters.Add('Recurse', $true)
             }
             else {
                 $Parameters.Add('Directory', $true)
@@ -77,13 +80,22 @@ Describe 'Splatting' {
 
         It 'can be built from automatic hashtables' {
             $String = "Folders:__"
-            $Parameters = if ($String -match 'Folders:(?<Filter>[a-z ])$') {
+            $Parameters = if ($String -match 'Folders:(?<Filter>[_\d\w ]*)$') {
+                <#Matches is automaticed populated by the -match operater in the if statement
+                If $String = "Folders:00_TheBasics"
+                Then $Matches holds the following:
+                Name                           Value
+                ----                           -----
+                Filter                         00_TheBasics
+                0                              Folders:00_TheBasics
+                #>
                 $Matches.Remove(0) # Remove the 'whole' match and keep only the portions we asked for
-                $Matches.Clone()
+                $Matches.Clone() #Matches.Clone() allows for the remaining matches to be assigned to $Parameters
             }
             $Parameters.Add('Path', $PSKoansFolder)
             $Parameters.Add('Directory', $true)
-            (Get-ChildItem @Parameters).Count | Should -Be 2
+            #Now w
+            (Get-ChildItem @Parameters).Count | Should -Be __
         }
     }
 }

--- a/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
@@ -95,7 +95,7 @@ Describe 'Splatting' {
             }
             $Parameters.Add('Path', $PSKoansFolder)
             $Parameters.Add('Directory', $true)
-            #Now w
+
             (Get-ChildItem @Parameters).Count | Should -Be __
         }
     }

--- a/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
@@ -90,7 +90,8 @@ Describe 'Splatting' {
                 0                              Folders:00_TheBasics
                 #>
                 $Matches.Remove(0) # Remove the 'whole' match and keep only the portions we asked for
-                $Matches.Clone() #Matches.Clone() allows for the remaining matches to be assigned to $Parameters
+                # Clone() copies the remaining matches, so we can store them with the $Parameters assignment above.
+                $Matches.Clone()
             }
             $Parameters.Add('Path', $PSKoansFolder)
             $Parameters.Add('Directory', $true)

--- a/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
@@ -81,13 +81,14 @@ Describe 'Splatting' {
         It 'can be built from automatic hashtables' {
             $String = "Folders:__"
             $Parameters = if ($String -match 'Folders:(?<Filter>[_\d\w ]*)$') {
-                <#Matches is automaticed populated by the -match operater in the if statement
-                If $String = "Folders:00_TheBasics"
-                Then $Matches holds the following:
-                Name                           Value
-                ----                           -----
-                Filter                         00_TheBasics
-                0                              Folders:00_TheBasics
+                <#
+                    Matches is automaticed populated by the -match operater in the if statement
+                    If $String = "Folders:00_TheBasics"
+                    Then $Matches holds the following:
+                    Name                           Value
+                    ----                           -----
+                    Filter                         00_TheBasics
+                    0                              Folders:00_TheBasics
                 #>
                 $Matches.Remove(0) # Remove the 'whole' match and keep only the portions we asked for
                 # Clone() copies the remaining matches, so we can store them with the $Parameters assignment above.


### PR DESCRIPTION
﻿# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->
Resolves #193 
## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->
Complex objects like Get-ChildItem will always fail the ` | should -be ` comparison. Comparing two properties of that object seems sufficient to prove that they are in fact the same after using the splatting operator. If the dual comparison is too much, could easily reduce to comparing just .name

 The last It block was inheritently difficult because the regex pattern no longer matches to any of the directory names. https://github.com/vexx32/PSKoans/blob/1edc1b91e6f92eae19dec46bb019c9222477218d/PSKoans/Koans/Constructs%20and%20Patterns/AboutSplatting.Koans.ps1#L80

Minor changes to the regex pattern and some additional comments should make it clear how to pass this Koan.
## Changes

- Remove -Recurse parameter from Get-ChildItem calls. There are plenty of examples later on that show how to include a switch parameter in a splat.
- Updated regex to include digits and '_'
- Added comments surrounding -match and $Matches

<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
