### PR TITLE
Fixes auto-succeeding pester tests in AboutComparison and AboutStrings

### DIFF
--- a/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
@@ -22,7 +22,7 @@ Describe 'Comparison Operators' {
 
         It 'is a simple test' {
             $true -eq $false | Should -Be $false
-            __ | Should -Be (1 -eq 1)
+            $__ | Should -Be (1 -eq 1)
         }
 
         It 'will attempt to convert types' {
@@ -168,8 +168,8 @@ Describe 'Logical Operators' {
 
         It 'returns $true if either input is $true' {
             $true -or $false | Should -Be $true
-            __ | Should -Be ($false -or $true)
-            __ | Should -Be ($true -or $true)
+            $__ | Should -Be ($false -or $true)
+            $__ | Should -Be ($true -or $true)
         }
 
         It 'may coerce values to boolean' {
@@ -193,7 +193,7 @@ Describe 'Logical Operators' {
 
         It 'negates a boolean value' {
             -not $true | Should -Be $false
-            __ | Should -Be (-not $false)
+            $__ | Should -Be (-not $false)
         }
 
         It 'can be shortened to !' {

--- a/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
@@ -22,7 +22,7 @@ Describe 'Comparison Operators' {
 
         It 'is a simple test' {
             $true -eq $false | Should -Be $false
-            $__ | Should -Be (1 -eq 1)
+            $____ | Should -Be (1 -eq 1)
         }
 
         It 'will attempt to convert types' {
@@ -168,8 +168,8 @@ Describe 'Logical Operators' {
 
         It 'returns $true if either input is $true' {
             $true -or $false | Should -Be $true
-            $__ | Should -Be ($false -or $true)
-            $__ | Should -Be ($true -or $true)
+            $____ | Should -Be ($false -or $true)
+            $____ | Should -Be ($true -or $true)
         }
 
         It 'may coerce values to boolean' {
@@ -193,7 +193,7 @@ Describe 'Logical Operators' {
 
         It 'negates a boolean value' {
             -not $true | Should -Be $false
-            $__ | Should -Be (-not $false)
+            $____ | Should -Be (-not $false)
         }
 
         It 'can be shortened to !' {

--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -102,7 +102,7 @@ Describe 'Strings' {
 
         It 'adds strings together' {
             # Two become one.
-            $String1 = 'This string'
+            $String1 = '__'
             $String2 = 'is cool.'
 
             $String1 + ' ' + $String2 | Should -Be 'This string is cool.'

--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -102,7 +102,7 @@ Describe 'Strings' {
 
         It 'adds strings together' {
             # Two become one.
-            $String1 = '__'
+            $String1 = '_____'
             $String2 = 'is cool.'
 
             $String1 + ' ' + $String2 | Should -Be 'This string is cool.'


### PR DESCRIPTION
﻿# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

This PR fixes pester tests from auto-succeeding.

This PR Resolves Issues #212 and #213 

I tested these changes to make sure they initially fail the pester tests successfully

## Context

The solution for the AboutComparison issues came from: https://github.com/vexx32/PSKoans/issues/212#issuecomment-507712857

The solution for the AboutString issues came from: https://github.com/vexx32/PSKoans/issues/213#issuecomment-507713959
<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

<!-- List any and all changes here, in bullet point form. -->

In AboutStrings:
- I replaced text in $String1 on line 105 that was causing the test to succeed without user input. 

In AboutComparison.Koans.ps1
-  I replaced 4 instances of __ with $__, where the pester tests were succeeding without user input, because __ was evaluating to $true which completed the test. 


## Checklist

- [X] Pull Request has a meaningful title.
- [X] Summarised changes.
- [X] Pull Request is ready to merge & is not WIP.
- [X] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [X] Added documentation / opened issue to track adding documentation at a later date.
