### PR TITLE
Fix #177 (unpredictable test expectations in AboutWhereObject)

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutWhereObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutWhereObject.Koans.ps1
@@ -28,7 +28,7 @@ Describe 'Where-Object' {
 
         # Pipelines also work across line breaks (as long as the pipe is at the end of the line)
         $Result = $ItemsWithNumbers |
-            Get-Random |
+            Select-Object -Last 1 |
             Select-Object -ExpandProperty Name
         __ | Should -Be $Result
     }


### PR DESCRIPTION
﻿# PR Summary

Fix #177 

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

 - Change `Get-Random` example pipeline element in AboutWhereObject to something more, eh, predictable 😅

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
