### PR TITLE
Improve Utility of Get-Blank

### DIFF
--- a/PSKoans/Public/Get-Blank.ps1
+++ b/PSKoans/Public/Get-Blank.ps1
@@ -1,8 +1,47 @@
 ﻿function Get-Blank {
+    <#
+        .SYNOPSIS
+        Get-Blank returns a blank object that represents no value, and is considered equal to
+        no other object or value.
+        
+        .DESCRIPTION
+        Get-Blank returns an object of type [Blank] as defined in the PSKoans module.
+        This object is not equivalent to any other type of object, including itself, when compared
+        with a standard `-eq` comparison.
+        
+        The only exception, which is unavoidable, is that it is considered equal to $true when
+        $true is on the left-hand side of the comparison. Tthis kind of comparison may sometimes
+        need to be carefully avoided when framing a koan assertion.
+        
+        For instance, the following assertion WILL pass, although it should not:
+        
+            ____ | Should -BeTrue
+            
+        .EXAMPLE
+        __ | Should -Be (4 + 1)
+        
+        .EXAMPLE
+        $Date = Get-Date
+        $____ | Should -Be $Date
+        
+        .EXAMPLE
+        $Num = Get-Random
+        ____ | Should -Not -Be $num
+    #>
     [CmdletBinding(HelpUri = 'https://github.com/vexx32/PSKoans/tree/master/docs/Get-Blank.md')]
     [OutputType('Blank')]
     [Alias('__', '____', 'FILL_ME_IN')]
-    param()
+    param(
+        # Used to capture the input in a pipeline context, to avoid erroring out in those contexts.
+        [Parameter(ValueFromPipeline)]
+        [object]
+        $PipeInput,
+        
+        # Used to capture parameter names and arguments when used as a substitute for any other cmdlet.
+        [Parameter(ValueFromRemainingArguments)]
+        [object[]]
+        $ParameterInput
+    )
 
     Write-Verbose "I AIN'T DOIN' NOTHIN'!!!"
 

--- a/PSKoans/Public/Get-Blank.ps1
+++ b/PSKoans/Public/Get-Blank.ps1
@@ -35,12 +35,12 @@
         # Used to capture the input in a pipeline context, to avoid erroring out in those contexts.
         [Parameter(ValueFromPipeline, DontShow)]
         [object]
-        $PipeInput,
+        ${|PipeInput},
         
         # Used to capture parameter names and arguments when used as a substitute for any other cmdlet.
         [Parameter(ValueFromRemainingArguments, DontShow)]
         [object[]]
-        $ParameterInput
+        ${|ParameterInput}
     )
 
     Write-Verbose "I AIN'T DOIN' NOTHIN'!!!"

--- a/PSKoans/Public/Get-Blank.ps1
+++ b/PSKoans/Public/Get-Blank.ps1
@@ -33,12 +33,12 @@
     [Alias('__', '____', 'FILL_ME_IN')]
     param(
         # Used to capture the input in a pipeline context, to avoid erroring out in those contexts.
-        [Parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline, DontShow)]
         [object]
         $PipeInput,
         
         # Used to capture parameter names and arguments when used as a substitute for any other cmdlet.
-        [Parameter(ValueFromRemainingArguments)]
+        [Parameter(ValueFromRemainingArguments, DontShow)]
         [object[]]
         $ParameterInput
     )

--- a/Tests/Functions/Public/Get-Blank.Tests.ps1
+++ b/Tests/Functions/Public/Get-Blank.Tests.ps1
@@ -4,4 +4,12 @@ Describe 'Get-Blank' {
     It 'should not produce output' {
         Get-Blank | Should -BeNullOrEmpty
     }
+    
+    It 'should be usable in the middle of a pipeline' {
+        { Get-Variable | Get-Blank | Write-Output } | Should -Not -Throw
+    }
+    
+    It 'should quietly ignore parameters' {
+        { Get-Blank -Param1 Value1 -Param2 Value2 } | Should -Not -Throw
+    }
 }


### PR DESCRIPTION
﻿# PR Summary

This PR allows Get-Blank to effectively replace _any_ command in the pipeline, including those that would be used in the middle of a pipeline, or those with parameters.

## Context

This is accomplished by offering dummy parameters for both pipeline and regular input. Regular input is taken with ValueFromRemainingArguments so as to capture both arbitrary named parameters and values, without throwing any errors during binding and allowing the assertion to behave correctly.

This allows syntax like this to frame koans:

```
Get-ChildItem | ____ -First 2 | Should -HaveCount 2
```

## Changes

- Add two parameters to Get-Blank, one for pipe input, one for input via ValueFromRemainingArguments
- Add comment based help for Get-Blank in case people get curious. It is a public-facing function, after all.


## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
