### PR TITLE
Measure-Object doesn't have 'Count' parameter

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutMeasureObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutMeasureObject.Koans.ps1
@@ -22,7 +22,7 @@ Describe 'Measure-Object' {
 
     It 'can count objects' {
         $Numbers |
-            Measure-Object -Count |
+            Measure-Object |
             Select-Object -ExpandProperty Count |
             Should -Be __
 

--- a/PSKoans/Koans/Cmdlets 1/AboutSelectObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutSelectObject.Koans.ps1
@@ -67,6 +67,6 @@ Describe 'Select-Object' {
         7, 3, 1, 2, 6, 3, 7, 1, 4, 5, 2, 1, 3, 6, 2, 5, 1, 4
 
         $UniqueItems = $Array | Select-Object -Unique
-        5, '__', 10, 9, '__', '__', '__', 7, '__', '__' | Should -Be $UniqueItems
+        6, '__', 4, 8, '__', '__', 3, '__', 2 | Should -Be $UniqueItems
     }
 }


### PR DESCRIPTION
﻿# PR Summary

Mesure-Object -Count results in an error "A parameter cannot be found that matches parameter name 'Count'." Checking online documentation revels that Measure-Object doesn't have 'Count' parameter. Removing 'Count' parameter works fine. 

Resolves #181

## Context

AboutMeasureObject

## Changes

* remove 'Count' parameter from Measure-Object cmd

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
