### PR TITLE
Update AboutStringBuilder koans

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
@@ -22,7 +22,7 @@ Describe 'System.Text.StringBuilder' {
             # All things, ultimately, are carved from a blank slate.
             $StringBuilder = New-Object System.Text.StringBuilder
 
-            $StringBuilder | Should -BeOfType __
+            $StringBuilder | Should -BeOfType ____
         }
 
         It 'can be created from a type accelerator' {
@@ -36,7 +36,7 @@ Describe 'System.Text.StringBuilder' {
                 without parentheses in the console to see available overload
                 definitions that can be used to construct the object.
             #>
-            $StringBuilder, $SBFromString, $SBWithSetCapacity | Should -BeOfType __
+            $StringBuilder, $SBFromString, $SBWithSetCapacity | Should -BeOfType ____
             __ | Should -Be $SBFromString.Length
         }
 
@@ -44,7 +44,7 @@ Describe 'System.Text.StringBuilder' {
             # Two sides of a coin.
             [System.Text.StringBuilder]$StringBuilder = 'Initial String'
 
-            $StringBuilder | Should -BeOfType __
+            $StringBuilder | Should -BeOfType ____
         }
     }
 
@@ -54,7 +54,7 @@ Describe 'System.Text.StringBuilder' {
             $StringBuilder = [System.Text.StringBuilder]::new()
 
             # Quantity comes first. Quality soon follows.
-            $StringBuilder.Append('__')
+            $StringBuilder.Append('____')
             $StringBuilder.Length | Should -Be 10
         }
 
@@ -64,8 +64,8 @@ Describe 'System.Text.StringBuilder' {
             $StringBuilder.AppendLine('Goodbye!')
 
             $ExpectedString = @"
-__
-__
+____
+____
 "@
             $ExpectedString | Should -Be $StringBuilder.ToString()
         }
@@ -74,13 +74,13 @@ __
             # Using the same underlying framework as the -f formatting operator.
             $StringBuilder = [System.Text.StringBuilder]::new()
 
-            $FormatItems = '__', '__'
-            $StringBuilder.AppendFormat("{0} is {1}.")
+            $FormatItems = '____', '____'
+            $StringBuilder.AppendFormat("{0} is {1}.", $FormatItems)
 
             $StringBuilder.ToString() | Should -Be "Water is wet."
         }
 
-        It 'returns a reference to the object' {
+        It 'returns a reference to the object when adding strings' {
             # So you can either hide that output, or use it to chain the method!
             $StringBuilder = [System.Text.StringBuilder]::new()
             $StringBuilder.Append('Hello!') > $null # Hide output from console
@@ -88,7 +88,7 @@ __
             # The reference returned points back to the original StringBuilder object.
             $StringBuilder.Append(' Who ').Append('are ').Append('you?') | Should -Be $StringBuilder
 
-            '__' | Should -Be $StringBuilder.ToString()
+            '____' | Should -Be $StringBuilder.ToString()
         }
     }
 
@@ -100,14 +100,14 @@ __
 
         It 'is as simple as calling .ToString()' {
             $SB.ToString() | Should -BeOfType String
-            '__' | Should -Be $SB.ToString()
+            '____' | Should -Be $SB.ToString()
         }
 
         It 'can be retained and reused' {
             $SB.Append('Hello')
-            '__' | Should -Be $SB.ToString()
+            '____' | Should -Be $SB.ToString()
             $SB.Append(' DONE')
-            '__' | Should -Be $SB.ToString()
+            '____' | Should -Be $SB.ToString()
         }
     }
 
@@ -124,18 +124,18 @@ __
             $StringBuilder.Append('is my dog.')
             $StringBuilder.Insert(0, 'Ben ')
 
-            '__' | Should -Be $StringBuilder.ToString()
+            '____' | Should -Be $StringBuilder.ToString()
         }
 
         It 'can remove sequences' {
-            '__' | Should -Be $StringBuilder.Remove(0, 4).ToString()
+            '____' | Should -Be $StringBuilder.Remove(0, 4).ToString()
         }
 
         It 'can replace existing sequences' {
             $StringBuilder.Insert(0, 'Steve ')
             $StringBuilder.Replace('dog', 'draconian leech')
 
-            '__' | Should -Be $StringBuilder.ToString()
+            '____' | Should -Be $StringBuilder.ToString()
         }
     }
 
@@ -148,7 +148,7 @@ __
 
         It 'has only a few properties' {
             $PropertyCount = __
-            $PropertyName = __
+            $PropertyName = '____'
 
             $Properties = $StringBuilder |
                 Get-Member |
@@ -169,7 +169,7 @@ __
             $FinalStringLength | Should -Be $StringBuilder.Length
         }
 
-        It 'indicates the currently allocated capactity' {
+        It 'indicates the currently allocated capacity' {
             $Capacity = __
 
             $Capacity | Should -Be $StringBuilder.Capacity

--- a/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
@@ -63,10 +63,11 @@ Describe 'System.Text.StringBuilder' {
             $StringBuilder.AppendLine('Hello!')
             $StringBuilder.AppendLine('Goodbye!')
 
-            $ExpectedString = @"
-____
-____
-"@
+            $ExpectedString = @(
+                '____'
+                '____'
+            ) -join [Environment]::NewLine
+
             $ExpectedString | Should -Be $StringBuilder.ToString()
         }
 
@@ -151,12 +152,12 @@ ____
             $PropertyName = '____'
 
             $Properties = $StringBuilder |
-                Get-Member |
-                Where-Object MemberType -eq 'Property'
+            Get-Member |
+            Where-Object MemberType -eq 'Property'
 
             $ExpectedCount = $Properties |
-                Measure-Object |
-                Select-Object -ExpandProperty Count
+            Measure-Object |
+            Select-Object -ExpandProperty Count
 
             $PropertyCount | Should -Be $ExpectedPropertyCount
             $PropertyName | Should -BeIn $Properties.Name

--- a/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
@@ -63,10 +63,12 @@ Describe 'System.Text.StringBuilder' {
             $StringBuilder.AppendLine('Hello!')
             $StringBuilder.AppendLine('Goodbye!')
 
-            $ExpectedString = @(
+            $ExpectedString = -join @(
                 '____'
+                [Environment]::NewLine
                 '____'
-            ) -join [Environment]::NewLine
+                [Environment]::NewLine
+            )
 
             $ExpectedString | Should -Be $StringBuilder.ToString()
         }


### PR DESCRIPTION
﻿# PR Summary

Updates format and fixes some minor spelling / code errors in AboutStringBuilder koans to make it more usable.

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

Resolves #188, superseding #202.
<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

* Updated style of blanks to current standards.
* Fixed spelling / minor code errors.
* Fixed xplat newline issue by avoiding literal here-string for the newlines.
<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
