### PR TITLE
Remove nonexistent parameter -Count

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutMeasureObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutMeasureObject.Koans.ps1
@@ -22,12 +22,12 @@ Describe 'Measure-Object' {
 
     It 'can count objects' {
         $Numbers |
-            Measure-Object -Count |
+            Measure-Object |
             Select-Object -ExpandProperty Count |
             Should -Be __
 
         $Files |
-            Measure-Object -Count |
+            Measure-Object |
             Select-Object -ExpandProperty Count |
             Should -Be __
     }


### PR DESCRIPTION
﻿# PR Summary

Fixes #181

## Changes

Removes nonexistent `-Count` parameter from `Measure-Object` calls. 

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
