### PR TITLE
Publish Test Results to Azure Pipelines

### DIFF
--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -8,7 +8,7 @@ Properties {
 
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"
     $PSVersion = $PSVersionTable.PSVersion
-    $TestFile = "TestResults_PS${PSVersion}_${TimeStamp}.xml"
+    $TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
     $Lines = '-' * 70
 
     $Continue = @{
@@ -53,7 +53,7 @@ STATUS: Testing with PowerShell $PSVersion
         Path         = "$ProjectRoot/Tests"
         PassThru     = $true
         OutputFormat = 'NUnitXml'
-        OutputFile   = "$ProjectRoot/$TestFile"
+        OutputFile   = "${env:Build_ArtifactStagingDirectory}/$TestFile"
         Show         = "Header", "Failed", "Summary"
     }
     $TestResults = Invoke-Pester @PesterParams
@@ -93,6 +93,5 @@ Continuing with existing version.
     }
 
     # Build external help files from Platyps MD files
-
     New-ExternalHelp -Path "$ProjectRoot/docs/" -OutputPath "$ProjectRoot/PSKoans/en-us"
 }

--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -56,7 +56,7 @@ STATUS: Testing with PowerShell $PSVersion
         Path         = "$ProjectRoot/Tests"
         PassThru     = $true
         OutputFormat = 'NUnitXml'
-        OutputFile   = "$env:Build_ArtifactStagingDirectory/$TestFile"
+        OutputFile   = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
         Show         = "Header", "Failed", "Summary"
     }
     $TestResults = Invoke-Pester @PesterParams

--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -56,7 +56,7 @@ STATUS: Testing with PowerShell $PSVersion
         Path         = "$ProjectRoot/Tests"
         PassThru     = $true
         OutputFormat = 'NUnitXml'
-        OutputFile   = "${env:Build_ArtifactStagingDirectory}/$TestFile"
+        OutputFile   = "$env:Build_ArtifactStagingDirectory/$TestFile"
         Show         = "Header", "Failed", "Summary"
     }
     $TestResults = Invoke-Pester @PesterParams

--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -63,8 +63,6 @@ STATUS: Testing with PowerShell $PSVersion
 
     [Net.ServicePointManager]::SecurityProtocol = $SecurityProtocol
 
-    Remove-Item -Path "$ProjectRoot/$TestFile" -Force -ErrorAction SilentlyContinue
-
     # Failed tests?
     # Need to tell psake or it will proceed to the deployment. Danger!
     if ($TestResults.FailedCount -gt 0) {

--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -48,6 +48,9 @@ STATUS: Testing with PowerShell $PSVersion
     $env:PSModulePath = '{0}{1}{2}' -f $ProjectRoot, ([System.IO.Path]::PathSeparator), $env:PSModulePath
     Import-Module 'PSKoans'
 
+    # Tell Azure where the test results file will be
+    Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
+
     # Gather test results. Store them in a variable and file
     $PesterParams = @{
         Path         = "$ProjectRoot/Tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,6 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: '$(TestResults).xml'
+      testResultsFiles: $(TestResults)
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: '*TestResults*.xml'
+      testResultsFiles: '$(TestResults);*TestResults*.xml'
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,6 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: $(TestResults)
+      testResultsFiles: '*.TestResults.xml'
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: '$(TestResults);*TestResults*.xml'
+      testResultsFiles: '$(TestResults)'
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,6 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: '*PSKoans.TestResults.xml'
+      testResultsFiles: '$(TestResults).xml'
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,6 @@ jobs:
     displayName: 'Publish Test Results'
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: '$(Package)*.xml'
+      testResultsFiles: '*PSKoans.TestResults.xml'
       searchFolder: '$(Build.ArtifactStagingDirectory)'
       mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,14 @@ jobs:
       failOnStderr: true
       pwsh: true
 
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '*TestResults*.xml'
+      searchFolder: '$(Build.ArtifactStagingDirectory)'
+      mergeTestResults: true
+
   - task: PowerShell@2
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     displayName: 'Deploy to Gallery'
@@ -60,11 +68,3 @@ jobs:
       errorActionPreference: 'stop'
       failOnStderr: true
       pwsh: true
-
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results'
-    inputs:
-      testResultsFormat: NUnit
-      testResultsFiles: '*.TestResults.xml'
-      searchFolder: '$(Build.ArtifactStagingDirectory)'
-      mergeTestResults: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,3 +60,11 @@ jobs:
       errorActionPreference: 'stop'
       failOnStderr: true
       pwsh: true
+
+  - task: PublishTestResults@2
+    displayName: 'Publish Test Results'
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '$(Package)*.xml'
+      searchFolder: '$(Build.ArtifactStagingDirectory)'
+      mergeTestResults: true


### PR DESCRIPTION
﻿# PR Summary

This adds a publishing step in the yaml and modifies the psake Test step to place the test results file in an appropriate location for Azure Pipelines to pick it up.

## Changes

- Added build step in yaml to publish tests
- Modified Psake Test step to save the Pester NUnitXml output file to the staging directory.
- Add Azure variable for test file name

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
