### PR TITLE
Add multi-platform building and testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,9 +45,9 @@ jobs:
 - job: PublishModule
   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   dependsOn:
-    - CI_Linux
-    - CI_Windows
-    - CI_MacOS
+    - Linux
+    - Windows
+    - MacOS
   pool:
     vmImage: ubuntu-latest
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,26 +16,26 @@ pr:
 
 jobs:
 
-- job: CI_Linux
+- job: Linux
   pool:
     vmImage: ubuntu-latest
 
   steps:
   - template: templates/build-steps.yml
   - task: PublishPipelineArtifact@1
-    displayName: 'Publish Help Artifacts'
+    displayName: 'Publish External Help Artifacts'
     inputs:
       path: '$(System.DefaultWorkingDirectory)/PSKoans/en-us'
       artifact: ExternalHelp
 
-- job: CI_Windows
+- job: Windows
   pool:
     vmImage: windows-latest
 
   steps:
   - template: templates/build-steps.yml
 
-- job: CI_MacOS
+- job: MacOS
   pool:
     vmImage: macOS-latest
 
@@ -53,6 +53,7 @@ jobs:
 
   steps:
   - task: DownloadPipelineArtifact@2
+    displayName: 'Download External Help Artifact'
     inputs:
       artifact: ExternalHelp
       path: '$(System.DefaultWorkingDirectory)/PSKoans/'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,6 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
+# YAML spec:
 # https://aka.ms/yaml
+
 name: Build & Test - Azure
 
 trigger:
@@ -17,47 +16,43 @@ pr:
 
 jobs:
 
-- job: BuildAndTest
+- job: PSKoans_CI_Linux
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: ubuntu-latest
 
   steps:
-  - task: PowerShell@2
-    displayName: 'Setup Build Environment'
+  - template: templates/build-steps.yml
 
+- job: PSKoans_CI_Windows
+  pool:
+    vmImage: windows-latest
+
+  steps:
+  - template: templates/build-steps.yml
+
+- job: PSKoans_CI_MacOS
+  pool:
+    vmImage: macOS-latest
+
+  steps:
+  - template: templates/build-steps.yml
+
+- job: PSKoans_Publish
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+  dependsOn:
+    - PSKoans_CI_Linux
+    - PSKoans_CI_Windows
+    - PSKoans_CI_MacOS
+  pool:
+    vmImage: ubuntu-latest
+
+  steps:
+  - task: DownloadPipelineArtifact@2
     inputs:
-
-      targetType: 'inline'
-      script: |
-        Install-Module -Name Psake, PSDeploy, BuildHelpers, Platyps -Force -Scope CurrentUser
-        Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
-
-      errorActionPreference: 'stop'
-      failOnStderr: true
-      pwsh: true
-
-  - task: PowerShell@2
-    displayName: 'Run Pester Tests'
-
-    inputs:
-      targetType: 'filePath'
-      filePath: ./Build/Build.ps1
-      arguments: -Task Build
-
-      errorActionPreference: 'stop'
-      failOnStderr: true
-      pwsh: true
-
-  - task: PublishTestResults@2
-    displayName: 'Publish Test Results'
-    inputs:
-      testResultsFormat: NUnit
-      testResultsFiles: '$(TestResults)'
-      searchFolder: '$(Build.ArtifactStagingDirectory)'
-      mergeTestResults: true
+      artifact: ExternalHelp
+      path: '$(System.DefaultWorkingDirectory)/PSKoans/'
 
   - task: PowerShell@2
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
     displayName: 'Deploy to Gallery'
 
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
   steps:
   - template: templates/build-steps.yml
 
-- job: PSKoans_Publish
+- job: PublishModule
   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   dependsOn:
     - CI_Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,21 +16,21 @@ pr:
 
 jobs:
 
-- job: PSKoans_CI_Linux
+- job: CI_Linux
   pool:
     vmImage: ubuntu-latest
 
   steps:
   - template: templates/build-steps.yml
 
-- job: PSKoans_CI_Windows
+- job: CI_Windows
   pool:
     vmImage: windows-latest
 
   steps:
   - template: templates/build-steps.yml
 
-- job: PSKoans_CI_MacOS
+- job: CI_MacOS
   pool:
     vmImage: macOS-latest
 
@@ -40,9 +40,9 @@ jobs:
 - job: PSKoans_Publish
   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
   dependsOn:
-    - PSKoans_CI_Linux
-    - PSKoans_CI_Windows
-    - PSKoans_CI_MacOS
+    - CI_Linux
+    - CI_Windows
+    - CI_MacOS
   pool:
     vmImage: ubuntu-latest
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,11 @@ jobs:
 
   steps:
   - template: templates/build-steps.yml
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Help Artifacts'
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/PSKoans/en-us'
+      artifact: ExternalHelp
 
 - job: CI_Windows
   pool:

--- a/templates/build-steps.yml
+++ b/templates/build-steps.yml
@@ -31,3 +31,9 @@ steps:
     testResultsFiles: '$(TestResults)'
     searchFolder: '$(Build.ArtifactStagingDirectory)'
     mergeTestResults: true
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Help Artifacts'
+  inputs:
+    path: '$(System.DefaultWorkingDirectory)/PSKoans/en-us'
+    artifact: ExternalHelp

--- a/templates/build-steps.yml
+++ b/templates/build-steps.yml
@@ -31,9 +31,3 @@ steps:
     testResultsFiles: '$(TestResults)'
     searchFolder: '$(Build.ArtifactStagingDirectory)'
     mergeTestResults: true
-
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish Help Artifacts'
-  inputs:
-    path: '$(System.DefaultWorkingDirectory)/PSKoans/en-us'
-    artifact: ExternalHelp

--- a/templates/build-steps.yml
+++ b/templates/build-steps.yml
@@ -1,0 +1,33 @@
+steps:
+- task: PowerShell@2
+  displayName: 'Setup Build Environment'
+
+  inputs:
+    targetType: 'inline'
+    script: |
+      Install-Module -Name Psake, PSDeploy, BuildHelpers, Platyps -Force -Scope CurrentUser
+      Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+
+    errorActionPreference: 'stop'
+    failOnStderr: true
+    pwsh: true
+
+- task: PowerShell@2
+  displayName: 'Run Pester Tests'
+
+  inputs:
+    targetType: 'filePath'
+    filePath: ./Build/Build.ps1
+    arguments: -Task Build
+
+    errorActionPreference: 'stop'
+    failOnStderr: true
+    pwsh: true
+
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: NUnit
+    testResultsFiles: '$(TestResults)'
+    searchFolder: '$(Build.ArtifactStagingDirectory)'
+    mergeTestResults: true


### PR DESCRIPTION
﻿# PR Summary

We need to test the code on all the main supported platforms -- Windows/MacOS/Linux. This PR adds build jobs for each OS to build and test with.

## Context

#234 details some outstanding issues with Mac support already. These may not be entirely avoidable with just CI testing, but this will go a long way into giving us early warning as to when something breaks.

## Changes

- Split out main build/test steps into template file.
- Add agent jobs for each major OS supported by PowerShell Core.
- Move publishing to gallery to a separate job, which depends on all the agent jobs completing successfully.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
