### PR TITLE
Adds new koan validation tests

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutCompareObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutCompareObject.Koans.ps1
@@ -1,5 +1,5 @@
 ﻿using module PSKoans
-[Koan(Position = 205)]
+[Koan(Position = 204)]
 param()
 <#
     Compare-Object

--- a/PSKoans/Koans/Cmdlets 1/AboutNewObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutNewObject.Koans.ps1
@@ -1,5 +1,5 @@
 ﻿using module PSKoans
-[Koan(Position = 204)]
+[Koan(Position = 203)]
 param()
 <#
     New-Object

--- a/PSKoans/Koans/Cmdlets 1/AboutSelectObject.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutSelectObject.Koans.ps1
@@ -1,5 +1,5 @@
 ﻿using module PSKoans
-[Koan(Position = 206)]
+[Koan(Position = 205)]
 param()
 <#
     Select-Object

--- a/PSKoans/Koans/Katas/SortingCharacters.Koans.ps1
+++ b/PSKoans/Koans/Katas/SortingCharacters.Koans.ps1
@@ -1,5 +1,5 @@
 using module PSKoans
-[Koan(Position = 115)]
+[Koan(Position = 151)]
 param()
 
 <#

--- a/PSKoans/Koans/Katas/TheStockChallenge.Koans.ps1
+++ b/PSKoans/Koans/Katas/TheStockChallenge.Koans.ps1
@@ -1,5 +1,5 @@
 ﻿using module PSKoans
-[Koan(Position = 114)]
+[Koan(Position = 150)]
 param()
 <#
     Apply Your Knowledge!

--- a/Tests/KoanValidation.Tests.ps1
+++ b/Tests/KoanValidation.Tests.ps1
@@ -55,7 +55,7 @@ Describe "Koan Assessment" {
 
     It "Should not have other PS1 files in the Koan directory" {
         Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.ps1' |
-            Where-Object BaseName -notmatch '\.Koans' |
+            Where-Object BaseName -notmatch '\.Koans$' |
             Should -BeNullOrEmpty
     }
 }

--- a/Tests/KoanValidation.Tests.ps1
+++ b/Tests/KoanValidation.Tests.ps1
@@ -1,12 +1,24 @@
+using module ..\PSKoans\PSKoans.psd1
+
 $ProjectRoot = Resolve-Path "$PSScriptRoot/.."
 $KoanFolder = $ProjectRoot | Join-Path -ChildPath 'PSKoans' | Join-Path -ChildPath 'Koans'
 
 Describe "Koan Assessment" {
 
-    $Scripts = Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.Koans.ps1'
-    
-    # TestCases are splatted to the script so we need hashtables
-    $TestCases = $Scripts | ForEach-Object { @{File = $_ } }
+    BeforeAll {
+        # TestCases are splatted to the script so we need hashtables
+        $TestCases = InModuleScope PSKoans {
+            Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.Koans.ps1' | ForEach-Object {
+                $commandInfo = Get-Command -Name $_.FullName -ErrorAction SilentlyContinue
+
+                @{
+                    File     = $_
+                    Position = $commandInfo.ScriptBlock.Attributes.Where{ $_.TypeID -match 'Koan' }.Position
+                }
+            }
+        }
+    }
+
     It "<File> koans should be valid powershell" -TestCases $TestCases {
         param($File)
 
@@ -19,8 +31,31 @@ Describe "Koan Assessment" {
 
     It "<File> should include one (and only one) line feed at end of file" -TestCases $TestCases {
         param($File)
+
         $crlf = [Regex]::Match(($File | Get-Content -Raw), '(\r?(?<lf>\n))+\Z')
         $crlf.Groups['lf'].Captures.Count | Should -Be 1
     }
 
+    It "<File> should have a Koan position" -TestCases $TestCases {
+        param($File, $Position)
+
+        $Position | Should -Not -BeNullOrEmpty
+        $Position | Should -BeGreaterThan 0
+    }
+
+    It "Should not duplicate the Koan Position" {
+        $DuplicatePosition = $TestCases |
+            ForEach-Object { [PSCustomObject]$_ } |
+            Group-Object Position |
+            Where-Object Count -gt 1 |
+            ForEach-Object { '{0}: {1}' -f $_.Name, ($_.Group.File -join ', ') }
+
+        $DuplicatePosition | Should -BeNullOrEmpty
+    }
+
+    It "Should not have other PS1 files in the Koan directory" {
+        Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.ps1' |
+            Where-Object BaseName -notmatch '\.Koans' |
+            Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
﻿# PR Summary

Adds new position and basic file name tests to KoanValidation.

## Context

Improves validation reducing manual work required to verify Koans have a meaningful unique position defined.

## Changes

* Adds test for declared Koan position
* Adds test for duplicate Koan position
* Adds test for (assumed) erroneously named files in the Koans directory
* Fixes duplicate position between AboutSelectObject and AboutMeasureObject

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
