### PR TITLE
Adds examples to AboutArrays

### DIFF
--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -211,7 +211,7 @@ Describe 'Arrays' {
         else {
             # Windows PowerShell 5 and below have to work a lot harder to achieve the same thing.
 
-            $letters = [Int][Char]$firstLetter..[Int][Char]$lastLetter -as [Char[]]
+            $letters = ([Int][Char]$firstLetter)..([Int][Char]$lastLetter) -as [Char[]]
 
             $letters | Should -Be 'a', 'b', 'c', 'd'
         }

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -245,7 +245,7 @@ Describe 'Arrays' {
             For example, each array has a Contains method.
         #>
 
-        $Numbers.Contains(3) | Should -BeTrue
+        $____ -eq $Numbers.Contains(3) | Should -BeTrue
 
         # The Contains method is case sensitive for arrays containing strings.
 

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -189,7 +189,8 @@ Describe 'Arrays' {
 
         $Array = 1, 2, 3, 4, 5
 
-        __..5 | Should -Be $Array
+        $StartIndex = __
+        $StartIndex..5 | Should -Be $Array
     }
 
     It 'an array of letters may be created from a range' {

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -197,7 +197,7 @@ Describe 'Arrays' {
         # An array of characters, or letters, can be created.
 
         $firstLetter = '____'
-        $lastLetter = '____'
+        $lastLetter = '__'
 
         if ($PSVersionTable.PSEdition -eq 'Core') {
             # PowerShell Core uses .. between the letters to create an array.

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -52,7 +52,7 @@ Describe 'Arrays' {
         $Ages = 12, 25, 18, 64
 
         { $Ages.Add(59) } | Should -Throw -ExpectedMessage '____'
-        { $Ages.Remove(12) } | Should -Throw -ExpectedMessage 'Collection was of a fixed size.'
+        { $Ages.Remove(12) } | Should -Throw -ExpectedMessage '____'
     }
 
     It 'new arrays are created using the addition operator' {

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -51,7 +51,7 @@ Describe 'Arrays' {
 
         $Ages = 12, 25, 18, 64
 
-        { $Ages.Add(59) } | Should -Throw -ExpectedMessage 'Collection was of a fixed size.'
+        { $Ages.Add(59) } | Should -Throw -ExpectedMessage '____'
         { $Ages.Remove(12) } | Should -Throw -ExpectedMessage 'Collection was of a fixed size.'
     }
 

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -61,6 +61,8 @@ Describe 'Arrays' {
             in the background when the addition operator is used.
         #>
 
+        $Ages = 12, 25, 18, 64
+
         $Age = __
         $Ages = $Ages + $Age
 
@@ -226,10 +228,10 @@ Describe 'Arrays' {
         '____' | Should -Be $Numbers.GetType().Name
 
         $Strings = 'first', 'second', 'third'
-        $Strings.GetType().Name | Should -Be 'Object[]'
+        '____' | Should -Be $Strings.GetType().Name
 
         $Processes = Get-Process
-        $Processes.GetType().Name | Should -Be 'Object[]'
+        '____' | Should -Be $Processes.GetType().Name
 
         <#
             The base type of Object[], Char[], and other fixed size array types is the System.Array
@@ -249,12 +251,12 @@ Describe 'Arrays' {
 
         # The Contains method is case sensitive for arrays containing strings.
 
-        $Strings.Contains('first') | Should -BeTrue
-        $Strings.Contains('First') | Should -BeFalse
+        $____ -eq $Strings.Contains('first') | Should -BeTrue
+        $____ -eq $Strings.Contains('First') | Should -BeTrue
 
         # PowerShell's -contains operator is not case sensitive.
 
-        $Strings -contains 'first' | Should -BeTrue
-        $Strings -contains 'First' | Should -BeTrue
+        $Strings -contains '____' | Should -BeTrue
+        $Strings -contains '____' | Should -BeTrue
     }
 }

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -196,7 +196,7 @@ Describe 'Arrays' {
     It 'an array of letters may be created from a range' {
         # An array of characters, or letters, can be created.
 
-        $firstLetter = '____'
+        $firstLetter = '__'
         $lastLetter = '__'
 
         if ($PSVersionTable.PSEdition -eq 'Core') {

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -21,8 +21,10 @@ Describe 'Arrays' {
         # The comma operator is used to create an array. Spaces are typically ignored.
         $Ages = 12, 25, 18, 64
 
-        # Individual elements of an array can be accessed with square-bracket index syntax.
-        # Arrays are zero-indexed; the first element is at index 0, the second at 1, etc.
+        <#
+            Individual elements of an array can be accessed with square-bracket index syntax.
+            Arrays are zero-indexed; the first element is at index 0, the second at 1, etc.
+        #>
         $Ages[0] | Should -Be 12
         __ | Should -Be $Ages[3]
 
@@ -42,6 +44,53 @@ Describe 'Arrays' {
 
         # Where is index 4 in the above array?
         __ | Should -Be $Names[4]
+    }
+
+    It 'arrays are fixed size, elements cannot be added or removed' {
+        # Most arrays in PowerShell are fixed size. Elements cannot be directly added or removed.
+
+        $Ages = 12, 25, 18, 64
+
+        { $Ages.Add(59) } | Should -Throw -ExpectedMessage 'Collection was of a fixed size.'
+        { $Ages.Remove(12) } | Should -Throw -ExpectedMessage 'Collection was of a fixed size.'
+    }
+
+    It 'new arrays are created using the addition operator' {
+        <#
+            To add an element to a fixed size array, a new array must be created. PowerShell does this
+            in the background when the addition operator is used.
+        #>
+
+        $Age = __
+        $Ages = $Ages + $Age
+
+        # The operation above can be shortened using the Add-and-Assign operator.
+
+        $Age = __
+        $Ages += $Age
+
+        $Ages | Should -Be 12, 25, 18, 64, 42, 59
+
+        <#
+            The cost of adding an element to an array in PowerShell like this increases with the
+            size of the array.
+
+            Each time a new element is added, the array must be copied to a new larger array to accommodate
+            the new values.
+
+            The result of the operation is another fixed size array.
+        #>
+    }
+
+    It 'the addition operator can be used to join two arrays together' {
+        $firstValue = __
+        $fourthValue = __
+
+        $Array = @($firstValue, 2) + @(3, $fourthValue)
+
+        # A new array is created to hold all of the values.
+
+        $Array | Should -Be 1, 2, 3, 4
     }
 
     It 'allows the collection to be split into multiple parts' {
@@ -82,6 +131,31 @@ Describe 'Arrays' {
         $Array[1, $Index, 4] | Should -Be @(2, 9, 5)
     }
 
+    It 'has properties which describe the size of the array' {
+        $Array = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+
+        __ | Should -Be $Array.Count
+
+        # For fixed size arrays, the Count property is an alias of Length
+
+        $Array.Count | Should -Be $Array.Length
+
+        <#
+            More advanced .NET collections do not have a Length property.
+            Count is the more reliable choice.
+
+            PowerShell adds the Count alias to fixed size arrays to make
+            working with arrays and array-like collections consistent.
+        #>
+
+        $Array = 1, 2, 3, 4
+        $List = [System.Collections.Generic.List[Int]]@(1, 2, 3, 4)
+
+        $List.Count | Should -Be $Array.Count
+
+        # The List collection used above is covered in more detail in a later Koan.
+    }
+
     It 'allows use of negative indexes' {
         $Array = 1, 2, 3, 4, 5, 6, 7
         __ | Should -Be $Array[-1] # What is the -1th item?
@@ -93,7 +167,7 @@ Describe 'Arrays' {
         $Index = __
         $Array[-3, $Index, -6] | Should -Be @(5, 1, 2)
 
-        # You can make clever use of this to reverse an entire array!
+        # You can make use of this to reverse an entire array
         $LastIndex = __ # Hint: needs to be a negative number!
         $Array[-1..$LastIndex] | Should -Be @(7, 6, 5, 4, 3, 2, 1)
     }
@@ -108,5 +182,78 @@ Describe 'Arrays' {
         __ | Should -Be $Array[-10]
 
         # NOTE: The above will actually throw errors if you have PowerShell running in Strict Mode.
+    }
+
+    It 'creates arrays from a range' {
+        # The .. notation used to reverse an array may be used to array.
+
+        $Array = 1, 2, 3, 4, 5
+
+        __..5 | Should -Be $Array
+    }
+
+    It 'an array of letters may be created from a range' {
+        # An array of characters, or letters, can be created.
+
+        $firstLetter = '____'
+        $lastLetter = '____'
+
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            # PowerShell Core uses .. between the letters to create an array.
+
+            $letters = $firstLetter..$lastLetter
+
+            $letters | Should -Be 'a', 'b', 'c', 'd'
+        }
+        else {
+            # Windows PowerShell 5 and below have to work a lot harder to achieve the same thing.
+
+            $letters = [Int][Char]$firstLetter..[Int][Char]$lastLetter -as [Char[]]
+
+            $letters | Should -Be 'a', 'b', 'c', 'd'
+        }
+    }
+
+    It 'Object[] and the Array type' {
+        <#
+            Arrays in PowerShell are created with the type Object[]. An array of Objects.
+
+            The Object type can hold anything at all. A numeric value, a character, a Process, and so on.
+        #>
+
+        $Numbers = 1, 2, 3, 4
+        $Numbers.GetType().Name | Should -Be 'Object[]'
+
+        $Strings = 'first', 'second', 'third'
+        $Strings.GetType().Name | Should -Be 'Object[]'
+
+        $Processes = Get-Process
+        $Processes.GetType().Name | Should -Be 'Object[]'
+
+        <#
+            The base type of Object[], Char[], and other fixed size array types is the System.Array
+            type, or [Array].
+
+            The [Array] type describes the Length property (aliased to Count), as well as other methods
+            which can be used to work with the array.
+
+            The available methods can be seen with Get-Member:
+
+                Get-Member -InputObject @()
+
+            For example, each array has a Contains method.
+        #>
+
+        $Numbers.Contains(3) | Should -BeTrue
+
+        # The Contains method is case sensitive for arrays containing strings.
+
+        $Strings.Contains('first') | Should -BeTrue
+        $Strings.Contains('First') | Should -BeFalse
+
+        # PowerShell's -contains operator is not case sensitive.
+
+        $Strings -contains 'first' | Should -BeTrue
+        $Strings -contains 'First' | Should -BeTrue
     }
 }

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -223,7 +223,7 @@ Describe 'Arrays' {
         #>
 
         $Numbers = 1, 2, 3, 4
-        $Numbers.GetType().Name | Should -Be 'Object[]'
+        '____' | Should -Be $Numbers.GetType().Name
 
         $Strings = 'first', 'second', 'third'
         $Strings.GetType().Name | Should -Be 'Object[]'


### PR DESCRIPTION
﻿# PR Summary

Updates the AboutArrays topic with new examples.

Fixes #194 

## Context

Adds a couple of new examples to AboutArrays, showing Count and briefly discussing + and +=.

## Changes

* Adds "arrays are fixed size, elements cannot be added or removed" (not interactive)
* Adds "new arrays are created using the addition operator" (needs tweaking I think)
* Adds "the addition operator can be used to join two arrays together"
* Adds "has properties which describe the size of the array"
* Adds "creates arrays from a range"
* Adds "an array of letters may be created from a range"
* Adds "Object[] and the Array type" (not interactive)

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
