### PR TITLE
Add Code Coverage Reports

### DIFF
--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -10,6 +10,10 @@ Properties {
     $PSVersion = $PSVersionTable.PSVersion
     $TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
     $CodeCoverageFile = "PS${PSVersion}_${TimeStamp}_PSKoans.CodeCoverage.xml"
+    $ModuleFolders = @(
+        Get-ChildItem -Path "$ProjectRoot/PSKoans" -Directory -Recurse |
+            Where-Object { 'Koans' -notin $_.Parent.Name, $_.Parent.Parent.Name }
+    ).FullName -join ';'
     $Lines = '-' * 70
 
     $Continue = @{
@@ -52,6 +56,7 @@ STATUS: Testing with PowerShell $PSVersion
     # Tell Azure where the test results & code coverage files will be
     Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
     Write-Host "##vso[task.setvariable variable=CodeCoverageFile]$CodeCoverageFile"
+    Write-Host "##vso[task.setvariable variable=SourceFolders]$ProjectRoot/PSKoans;$ModuleFolders"
 
     # Gather test results. Store them in a variable and file
     $PesterParams = @{
@@ -60,7 +65,7 @@ STATUS: Testing with PowerShell $PSVersion
         OutputFormat           = 'NUnitXml'
         OutputFile             = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
         Show                   = "Header", "Failed", "Summary"
-        CodeCoverage           = "$ProjectRoot/PSKoans/"
+        CodeCoverage           = (Get-ChildItem -Recurse -Path "$ProjectRoot/PSKoans" -Filter '*.ps*1' -Exclude '*.Koans.ps1').FullName
         CodeCoverageOutputFile = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$CodeCoverageFile"
     }
     $TestResults = Invoke-Pester @PesterParams

--- a/Build/Psake.ps1
+++ b/Build/Psake.ps1
@@ -9,6 +9,7 @@ Properties {
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"
     $PSVersion = $PSVersionTable.PSVersion
     $TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
+    $CodeCoverageFile = "PS${PSVersion}_${TimeStamp}_PSKoans.CodeCoverage.xml"
     $Lines = '-' * 70
 
     $Continue = @{
@@ -48,16 +49,19 @@ STATUS: Testing with PowerShell $PSVersion
     $env:PSModulePath = '{0}{1}{2}' -f $ProjectRoot, ([System.IO.Path]::PathSeparator), $env:PSModulePath
     Import-Module 'PSKoans'
 
-    # Tell Azure where the test results file will be
+    # Tell Azure where the test results & code coverage files will be
     Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
+    Write-Host "##vso[task.setvariable variable=CodeCoverageFile]$CodeCoverageFile"
 
     # Gather test results. Store them in a variable and file
     $PesterParams = @{
-        Path         = "$ProjectRoot/Tests"
-        PassThru     = $true
-        OutputFormat = 'NUnitXml'
-        OutputFile   = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
-        Show         = "Header", "Failed", "Summary"
+        Path                   = "$ProjectRoot/Tests"
+        PassThru               = $true
+        OutputFormat           = 'NUnitXml'
+        OutputFile             = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
+        Show                   = "Header", "Failed", "Summary"
+        CodeCoverage           = "$ProjectRoot/PSKoans/"
+        CodeCoverageOutputFile = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$CodeCoverageFile"
     }
     $TestResults = Invoke-Pester @PesterParams
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PowerShell Koans
 
-| [![PSKoans Logo](./logo-128px.png)](./logo.svg) |
-| :---------------------------------------------: |
-| [![Build Status][build-badge]][build-link]      |
+| [![PSKoans Logo](./logo-128px.png)](./logo.svg)                                                 |
+| :---------------------------------------------------------------------------------------------: |
+| [![Build Status][build-badge]][build-link]<br/>[![Coverage Status][coverage-badge]][build-link] |
 
 ## About the Author
 
@@ -178,7 +178,8 @@ Good luck!
 
 ## Contributing
 
-If you would like to contribute to PSKoans, please check out the [Contributing](https://github.com/vexx32/PSKoans/blob/master/CONTRIBUTING.md) document. 
+If you would like to contribute to PSKoans, please check out the [Contributing](https://github.com/vexx32/PSKoans/blob/master/CONTRIBUTING.md) document.
 
 [build-badge]: https://dev.azure.com/SallowCode/PSKoans/_apis/build/status/PSKoans%20CI
 [build-link]: https://dev.azure.com/SallowCode/PSKoans/_build/latest?definitionId=1
+[coverage-badge]: https://img.shields.io/azure-devops/coverage/SallowCode/PSKoans/1

--- a/templates/build-steps.yml
+++ b/templates/build-steps.yml
@@ -32,3 +32,21 @@ steps:
     testResultsFiles: '$(TestResults)'
     searchFolder: '$(Build.ArtifactStagingDirectory)'
     mergeTestResults: true
+
+#- task: reportgenerator@4
+#  displayName: ReportGenerator
+#  inputs:
+#    reports: '$(CodeCoverageFile)'
+#    reporttypes: 'HtmlInline_AzurePipelines'
+#    sourcedirs: '$(Build.ArtifactStagingDirectory)'
+#    targetdir: coveragereport
+#  condition: succeededOrFailed()
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: JaCoCo
+    summaryFileLocation: '$(Build.ArtifactStagingDirectory)/$(CodeCoverageFile)'
+    reportDirectory: '$(Build.ArtifactStagingDirectory)'
+    pathToSources: '$(SourceFolders)'
+  displayName: 'Code Coverage'
+  condition: succeededOrFailed()

--- a/templates/build-steps.yml
+++ b/templates/build-steps.yml
@@ -27,26 +27,19 @@ steps:
 - task: PublishTestResults@2
   displayName: 'Publish Test Results'
   condition: succeededOrFailed()
+
   inputs:
     testResultsFormat: NUnit
     testResultsFiles: '$(TestResults)'
     searchFolder: '$(Build.ArtifactStagingDirectory)'
     mergeTestResults: true
 
-#- task: reportgenerator@4
-#  displayName: ReportGenerator
-#  inputs:
-#    reports: '$(CodeCoverageFile)'
-#    reporttypes: 'HtmlInline_AzurePipelines'
-#    sourcedirs: '$(Build.ArtifactStagingDirectory)'
-#    targetdir: coveragereport
-#  condition: succeededOrFailed()
-
 - task: PublishCodeCoverageResults@1
+  displayName: 'Publish Code Coverage'
+  condition: succeededOrFailed()
+
   inputs:
     codeCoverageTool: JaCoCo
     summaryFileLocation: '$(Build.ArtifactStagingDirectory)/$(CodeCoverageFile)'
-    reportDirectory: '$(Build.ArtifactStagingDirectory)'
+    #reportDirectory: '$(Build.ArtifactStagingDirectory)'
     pathToSources: '$(SourceFolders)'
-  displayName: 'Code Coverage'
-  condition: succeededOrFailed()


### PR DESCRIPTION
﻿# PR Summary

Generate and publish code coverage reports to Azure Pipelines.

## Context

Resolves #258

## Changes

- Add CodeCoverage generation to Psake test step
- Add Azure pipelines steps to generate coverage reports
- Add overall coverage % button to README.md

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
