### PR TITLE
(doc) Remove double space

### DIFF
--- a/PSKoans/Koans/Foundations/AboutAssertions.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutAssertions.Koans.ps1
@@ -17,7 +17,7 @@ param()
     has failed. Your job is to fill in the blanks (the __, $__, FILL_ME_IN,
     or $FILL_ME_IN symbols) to make it pass. Once you make the change,
     re-run the program to make sure the koan passes, and continue on to the
-    next failing koan. With each  passing koan, you'll learn more about
+    next failing koan. With each passing koan, you'll learn more about
     PowerShell, and add another weapon to your PowerShell scripting arsenal.
 #>
 Describe 'Equality' {


### PR DESCRIPTION
# PR Summary

Typo.  Once seen, it cannot be unseen 😄

## Context

I was reading through the docs on the introduction to PSKoans, and I happened to notice a double space, where one wasn't required.

## Changes

Removed duplicate space that is not required.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
