### PR TITLE
 Fix "Show-Advice" requiring full basename for snippet

### DIFF
--- a/PSKoans/Init/RegisterArgumentCompleters.ps1
+++ b/PSKoans/Init/RegisterArgumentCompleters.ps1
@@ -4,6 +4,8 @@ $CommandName = @(
     'Reset-PSKoan'
     'Show-Karma'
     'Update-PSKoan'
+    'Show-Advice'
+    'Get-Advice'
 )
 
 #region Topic completer
@@ -42,6 +44,31 @@ $RegisterParams = @{
 Register-ArgumentCompleter @RegisterParams
 
 $RegisterParams.ParameterName = 'IncludeModule'
+Register-ArgumentCompleter @RegisterParams
+
+#endregion
+
+#region Name completer
+
+$RegisterParams = @{
+    CommandName   = $CommandName
+    ParameterName = 'Name'
+    ScriptBlock   = {
+        param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
+
+        $Values = Get-Module PSKoans |
+            Select-Object -ExpandProperty ModuleBase |
+            Join-Path -ChildPath 'Data/Advice' |
+            Get-ChildItem -File -Recurse |
+            Select-Object @{
+                Name       = 'Name';
+                Expression = { $_.BaseName.Replace('.Advice', '') }
+            } |
+            Select-Object -ExpandProperty Name
+
+        return @($Values) -like "$WordToComplete*"
+    }
+}
 Register-ArgumentCompleter @RegisterParams
 
 #endregion

--- a/PSKoans/Init/RegisterArgumentCompleters.ps1
+++ b/PSKoans/Init/RegisterArgumentCompleters.ps1
@@ -32,8 +32,7 @@ $RegisterParams = @{
     ScriptBlock   = {
         param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
 
-        $Values = Get-Module PSKoans |
-            Select-Object -ExpandProperty ModuleBase |
+        $Values = $script:ModuleRoot |
             Join-Path -ChildPath 'Koans/Modules' |
             Get-ChildItem -Directory |
             Select-Object -ExpandProperty Name
@@ -56,8 +55,7 @@ $RegisterParams = @{
     ScriptBlock   = {
         param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)
 
-        $Values = Get-Module PSKoans |
-            Select-Object -ExpandProperty ModuleBase |
+        $Values = $script:ModuleRoot |
             Join-Path -ChildPath 'Data/Advice' |
             Get-ChildItem -File -Recurse |
             Select-Object @{

--- a/PSKoans/Init/RegisterArgumentCompleters.ps1
+++ b/PSKoans/Init/RegisterArgumentCompleters.ps1
@@ -4,6 +4,9 @@ $CommandName = @(
     'Reset-PSKoan'
     'Show-Karma'
     'Update-PSKoan'
+)
+
+$AdviceCommandName = @(
     'Show-Advice'
     'Get-Advice'
 )
@@ -47,10 +50,10 @@ Register-ArgumentCompleter @RegisterParams
 
 #endregion
 
-#region Name completer
+#region Name completer for *-Advice command names
 
 $RegisterParams = @{
-    CommandName   = $CommandName
+    CommandName   = $AdviceCommandName
     ParameterName = 'Name'
     ScriptBlock   = {
         param($Command, $Parameter, $WordToComplete, $CommandAst, $FakeBoundParams)

--- a/PSKoans/Public/Show-Advice.ps1
+++ b/PSKoans/Public/Show-Advice.ps1
@@ -11,7 +11,7 @@
         $AdviceFolder = $script:ModuleRoot | Join-Path -ChildPath 'Data/Advice'
     }
     process {
-        $AdviceObject = Get-ChildItem -Path $AdviceFolder -Recurse -File -Filter "$Name.json" |
+        $AdviceObject = Get-ChildItem -Path $AdviceFolder -Recurse -File -Filter "$Name.Advice.json" |
         Get-Random |
         Get-Content |
         ConvertFrom-Json


### PR DESCRIPTION
# PR Summary

Fixes #261 

## Context

Fixed 'Show-Advice' cmdlet requiring full basename to print advice snippet and improved cmdlet's support for tab completion, which was non-existent before. 

There are no tests for this change, but I am more than willing to try and implement them, but before I tack something on: should those tests be created into a separate _Show-Advice.Tests.ps1_ tests file or is there already an existing set of tests for advices that I am not seeing?

## Changes

- Hardcoded _Advice._ to `Get-ChildItem` filter to _Show-Advice.ps1_
  - If the format of the advice snippet is standardized to always be _Advice.json_, then is hardcoding still an issue?
- Added `Show-Advice` and `Get-Advice` to array of commands in _RegisterArgumentCompleters.ps1_
- Created separate 'completer' region for **Name** parameter

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
