### PR TITLE
Update-PSKoan - Fix "Yes to All" for ShouldProcess Prompts

### DIFF
--- a/PSKoans/Private/Update-PSKoanFile.ps1
+++ b/PSKoans/Private/Update-PSKoanFile.ps1
@@ -40,53 +40,55 @@ function Update-PSKoanFile {
     $PSBoundParameters.Remove('Confirm') > $null
     $PSBoundParameters.Remove('WhatIf') > $null
     Get-PSKoan @PSBoundParameters | ForEach-Object {
-        $moduleKoans = Get-KoanIt -Path $_.Path | ForEach-Object {
-            [PSCustomObject]@{
-                ID   = $_.ID
-                Name = $_.Name
-                Ast  = $_.Ast
-            }
-        } | Group-Object -Property ID -AsHashTable -AsString
-
-    if (-not $moduleKoans) {
-        # Handles topics which do not have It blocks.
-        return
-    }
-
-    $path = Get-PSKoanLocation | Join-Path -ChildPath $_.RelativePath
-
-    if (Test-Path -Path $path) {
-        $userKoans = Get-KoanIt -Path $path
-        $userKoansHash = $userKoans | Group-Object ID -AsHashTable -AsString
-
-        if ($moduleKoans.Keys.Where{ -not ($userKoansHash -and $userKoansHash.Contains($_)) }) {
-            $content = Get-Content -Path $_.Path -Raw
-
-            $userKoans |
-                Where-Object { $moduleKoans.Contains($_.ID) } |
-                Select-Object -Property @(
-                    'ID'
-                    'Name'
-                    'Ast'
-                    @{ Name = 'SourceAst'; Expression = { $moduleKoans[$_.ID].Ast } }
-                ) |
-                Sort-Object { $_.SourceAst.Extent.StartLineNumber } -Descending |
-                ForEach-Object {
-                    # Replace the content of the koan with the users content.
-                    $content = $content.Remove(
-                        $_.SourceAst.Extent.StartOffset,
-                        ($_.SourceAst.Extent.EndOffset - $_.SourceAst.Extent.StartOffset)
-                    ).Insert(
-                        $_.SourceAst.Extent.StartOffset,
-                        $_.Ast.Extent.Text
-                    )
+        $moduleKoans = Get-KoanIt -Path $_.Path |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    ID   = $_.ID
+                    Name = $_.Name
+                    Ast  = $_.Ast
                 }
+            } |
+            Group-Object -Property ID -AsHashTable -AsString
 
-            Set-Content -Path $path -Value $content.TrimEnd() -NoNewline
+        if (-not $moduleKoans) {
+            # Handles topics which do not have It blocks.
+            return
+        }
+
+        $path = Get-PSKoanLocation | Join-Path -ChildPath $_.RelativePath
+
+        if (Test-Path -Path $path) {
+            $userKoans = Get-KoanIt -Path $path
+            $userKoansHash = $userKoans | Group-Object ID -AsHashTable -AsString
+
+            if ($moduleKoans.Keys.Where{ -not ($userKoansHash -and $userKoansHash.Contains($_)) }) {
+                $content = Get-Content -Path $_.Path -Raw
+
+                $userKoans |
+                    Where-Object { $moduleKoans.Contains($_.ID) } |
+                    Select-Object -Property @(
+                        'ID'
+                        'Name'
+                        'Ast'
+                        @{ Name = 'SourceAst'; Expression = { $moduleKoans[$_.ID].Ast } }
+                    ) |
+                    Sort-Object { $_.SourceAst.Extent.StartLineNumber } -Descending |
+                    ForEach-Object {
+                        # Replace the content of the koan with the users content.
+                        $content = $content.Remove(
+                            $_.SourceAst.Extent.StartOffset,
+                            ($_.SourceAst.Extent.EndOffset - $_.SourceAst.Extent.StartOffset)
+                        ).Insert(
+                            $_.SourceAst.Extent.StartOffset,
+                            $_.Ast.Extent.Text
+                        )
+                    }
+
+                Set-Content -Path $path -Value $content.TrimEnd() -NoNewline
+            }
+        }
+        else {
+            Write-Warning ('Unexpected error, the koan topic {0} does not exist in the user store' -f $_.Name)
         }
     }
-    else {
-        Write-Warning ('Unexpected error, the koan topic {0} does not exist in the user store' -f $_.Name)
-    }
-}
 }

--- a/PSKoans/Public/Update-PSKoan.ps1
+++ b/PSKoans/Public/Update-PSKoan.ps1
@@ -1,10 +1,7 @@
 using namespace System.Collections.Generic
 
 function Update-PSKoan {
-    [CmdletBinding(
-        SupportsShouldProcess,
-        DefaultParameterSetName = 'TopicOnly',
-        ConfirmImpact = "High",
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'TopicOnly', ConfirmImpact = "High",
         HelpUri = 'https://github.com/vexx32/PSKoans/tree/master/docs/Update-PSKoan.md')]
     [OutputType([void])]
     param(
@@ -36,8 +33,8 @@ function Update-PSKoan {
     }
     switch ($pscmdlet.ParameterSetName) {
         'IncludeModule' { $GetParams['IncludeModule'] = $IncludeModule }
-        'ModuleOnly'    { $GetParams['Module'] = $Module }
-        { $Topic }      { $GetParams['Topic'] = $Topic }
+        'ModuleOnly' { $GetParams['Module'] = $Module }
+        { $Topic } { $GetParams['Topic'] = $Topic }
     }
     $ModuleKoanList = Get-PSKoan @GetParams | Group-Object Topic -AsHashtable -AsString
 
@@ -84,7 +81,9 @@ function Update-PSKoan {
                 }
             }
 
-            Update-PSKoanFile -Topic $_
+            if ($PSCmdlet.ShouldProcess($_, 'Updating Koan Topic')) {
+                Update-PSKoanFile -Topic $_
+            }
 
             continue
         }

--- a/PSKoans/Public/Update-PSKoan.ps1
+++ b/PSKoans/Public/Update-PSKoan.ps1
@@ -74,14 +74,14 @@ function Update-PSKoan {
         #>
         { $ModuleKoanList.ContainsKey($_) -and $UserKoanList.ContainsKey($_) } {
             if ($UserKoanList[$_].Path -ne $DestinationPath) {
-                if ($PSCmdlet.ShouldProcess($_, 'Moving Topic')) {
+                if ($PSCmdlet.ShouldProcess($_, 'Move Topic')) {
                     Write-Verbose "Moving $_"
 
                     $UserKoanList[$_].Path | Move-Item -Destination $DestinationPath
                 }
             }
 
-            if ($PSCmdlet.ShouldProcess($_, 'Updating Koan Topic')) {
+            if ($PSCmdlet.ShouldProcess($_, 'Update Koan Topic')) {
                 Update-PSKoanFile -Topic $_
             }
 
@@ -94,7 +94,7 @@ function Update-PSKoan {
             location.
         #>
         { $ModuleKoanList.ContainsKey($_) } {
-            if ($PSCmdlet.ShouldProcess($_, 'Adding Topic')) {
+            if ($PSCmdlet.ShouldProcess($_, 'Add Topic')) {
                 Write-Verbose "Adding $_"
 
                 $ModuleKoanList[$_].Path | Copy-Item -Destination $DestinationPath -Force
@@ -109,7 +109,7 @@ function Update-PSKoan {
             or renamed and delete the file from the users koan location.
         #>
         { $UserKoanList.ContainsKey($_) } {
-            if ($PSCmdlet.ShouldProcess($_, 'Removing Topic')) {
+            if ($PSCmdlet.ShouldProcess($_, 'Remove Topic')) {
                 Write-Verbose "Removing $_"
 
                 $UserKoanList[$_].Path | Remove-Item


### PR DESCRIPTION
﻿# PR Summary

Currently, Update-PSKoan prompts for every file updated, even if the user selects "A" for "Yes to All" at one of the prompts.

Fix is to have the ShouldProcess check only in the iterating function, and allow the child function to use that preference instead of checking each time it is called.

## Context

The reason this is needed appears to be that "yes to all" is only respected for the duration of the current function. Since `Update-PSKoanFile` was being called once for every file that needed updating, the prompt was unable to remember the user's selection from the prior call. 

Moving the ShouldProcess test into the parent `Update-PSKoan` function appears to resolve the issue most neatly.

## Changes

* Move `$PSCmdlet.ShouldProcess()` test from `Update-PSKoanFile` itself into `Update-PSKoan` and test before calling the private function.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
