### PR TITLE
Properly Rethrow Get-Karma errors in Show-Karma

### DIFF
--- a/PSKoans/Public/Get-Karma.ps1
+++ b/PSKoans/Public/Get-Karma.ps1
@@ -29,8 +29,8 @@
     }
     switch ($pscmdlet.ParameterSetName) {
         'IncludeModule' { $GetParams['IncludeModule'] = $IncludeModule }
-        'ModuleOnly'    { $GetParams['Module'] = $Module }
-        { $Topic }      { $GetParams['Topic'] = $Topic }
+        'ModuleOnly' { $GetParams['Module'] = $Module }
+        { $Topic } { $GetParams['Topic'] = $Topic }
     }
     switch ($PSCmdlet.ParameterSetName) {
         'ListKoans' {
@@ -51,12 +51,15 @@
 
             if ($TotalKoans -eq 0) {
                 if ($Topic) {
+                    $Message = 'Could not find any PSKoans topics that match requested Topic(s): {0}'
+                    $TopicList = $Topic -join ','
+
                     $ErrorDetails = @{
                         ExceptionType    = 'System.IO.FileNotFoundException'
-                        ExceptionMessage = 'Could not find any koans that match the specified Topic(s)'
+                        ExceptionMessage = $Message -f $TopicList
                         ErrorId          = 'PSKoans.NoMatchingKoansFound'
                         ErrorCategory    = 'ObjectNotFound'
-                        TargetObject     = $Topic -join ','
+                        TargetObject     = $TopicList
                     }
                     $PSCmdlet.ThrowTerminatingError( (New-PSKoanErrorRecord @ErrorDetails) )
                 }

--- a/PSKoans/Public/Get-Karma.ps1
+++ b/PSKoans/Public/Get-Karma.ps1
@@ -51,13 +51,16 @@
 
             if ($TotalKoans -eq 0) {
                 if ($Topic) {
-                    $Message = 'Could not find any PSKoans topics that match requested Topic(s): {0}'
+                    $Message = @(
+                        'Could not find any PSKoans topics matching Topic(s): {0}.'
+                        'Use Update-PSKoan to ensure your koan library is up to date.'
+                    ) -join ' '
                     $TopicList = $Topic -join ','
 
                     $ErrorDetails = @{
                         ExceptionType    = 'System.IO.FileNotFoundException'
                         ExceptionMessage = $Message -f $TopicList
-                        ErrorId          = 'PSKoans.NoMatchingKoansFound'
+                        ErrorId          = 'PSKoans.TopicNotFound'
                         ErrorCategory    = 'ObjectNotFound'
                         TargetObject     = $TopicList
                     }

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -85,14 +85,14 @@ function Show-Karma {
                 Clear-Host
             }
 
+            Show-MeditationPrompt -Greeting
+
             try {
                 $Results = Get-Karma @GetParams
             }
             catch {
                 $PSCmdlet.ThrowTerminatingError($_)
             }
-
-            Show-MeditationPrompt -Greeting
 
             if ($Results.Complete) {
                 $Params = @{

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -48,10 +48,10 @@ function Show-Karma {
     )
 
     $GetParams = @{ }
-    switch ($pscmdlet.ParameterSetName) {
+    switch ($PSCmdlet.ParameterSetName) {
         'IncludeModule' { $GetParams['IncludeModule'] = $IncludeModule }
         'ModuleOnly' { $GetParams['Module'] = $Module }
-        { $Topic } { $GetParams['Topic'] = $Topic }
+        { $PSBoundParameters.ContainsKey('Topic') } { $GetParams['Topic'] = $Topic }
     }
 
     switch ($PSCmdlet.ParameterSetName) {
@@ -85,8 +85,14 @@ function Show-Karma {
                 Clear-Host
             }
 
+            try {
+                $Results = Get-Karma @GetParams
+            }
+            catch {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+
             Show-MeditationPrompt -Greeting
-            $Results = Get-Karma @GetParams
 
             if ($Results.Complete) {
                 $Params = @{

--- a/Tests/Functions/Public/Get-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Get-Karma.Tests.ps1
@@ -55,7 +55,7 @@ InModuleScope 'PSKoans' {
             }
 
             It 'throws an error if a Topic is specified that matches nothing' {
-                { Get-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ExpectedMessage 'Could not find any koans'
+                { Get-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound'
             }
         }
 
@@ -115,7 +115,8 @@ InModuleScope 'PSKoans' {
 
                 try {
                     $Result = Get-Karma -Topic SelectedTopicTest
-                } catch {
+                }
+                catch {
                     # Ignore this. Error tests follow.
                 }
             }

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -124,7 +124,7 @@ Describe 'Show-Karma' {
             }
 
             It 'throws an error if a Topic is specified that matches nothing' {
-                { Show-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ExpectedMessage 'Could not find any koans'
+                { Show-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound'
             }
         }
 


### PR DESCRIPTION
﻿# PR Summary

Before this PR, Show-Karma did not properly catch and rethrow errors from Get-Karma, causing the user to receive errors from Get-Karma _and_ Show-MeditationPrompt when calling Show-Karma, which is unnecessary and confusing.

## Context

One error that clearly comes from Show-Karma rather than two errors from the internal functions it's calling is a much better UX.

## Changes

- Properly rethrow Get-Karma errors from Show-Karma.
- Update Get-Karma error messages to be more useful.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
