### PR TITLE
Reduce space around progress bars

### DIFF
--- a/PSKoans/Private/Show-MeditationPrompt.ps1
+++ b/PSKoans/Private/Show-MeditationPrompt.ps1
@@ -128,9 +128,9 @@ function Show-MeditationPrompt {
                         $CurrentTopic.Name
                     )
                     Write-Host $ProgressBar @Blue
+                    Write-Host
                 }
                 #endregion TopicProgressBar
-                Write-Host
 
                 if ($PSBoundParameters.ContainsKey('Results')) {
                     foreach ($KoanResult in $Results) {
@@ -145,7 +145,6 @@ function Show-MeditationPrompt {
                     }
                 }
 
-                Write-Host
                 #region TotalProgressBar
                 [int] $PortionDone = ($KoansPassed / $TotalKoans) * $ProgressWidth
 


### PR DESCRIPTION
﻿# PR Summary

Tidies up unnecessary spacing around progress bars.

## Changes

- Adjust space around progress bars in Show-MeditationPrompt.

### Examples

#### Multiple Topics (Before)

![image](https://user-images.githubusercontent.com/32407840/67640984-8b940680-f8d4-11e9-9cf0-4ae6b33baea7.png)

#### Multiple Topics (After)

![image](https://user-images.githubusercontent.com/32407840/67640960-656e6680-f8d4-11e9-9aec-13f55b3f0ef6.png)

#### Single Topic (Before)

![image](https://user-images.githubusercontent.com/32407840/67641009-d31a9280-f8d4-11e9-863c-460113c018ba.png)\

#### Single Topic (After)

![image](https://user-images.githubusercontent.com/32407840/67641015-e2014500-f8d4-11e9-95de-d14b4a5687d6.png)

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
