### PR TITLE
Fix issue where importing the module a second time fails

### DIFF
--- a/PSKoans/Classes/KoanAttribute.ps1
+++ b/PSKoans/Classes/KoanAttribute.ps1
@@ -1,9 +1,13 @@
-Add-Type -TypeDefinition @'
-using System;
-
-public class KoanAttribute : Attribute
-{
-    public uint Position = UInt32.MaxValue;
-    public string Module = "_powershell";
+if ('KoanAttribute' -as [type]) {
+    return
 }
+
+Add-Type -TypeDefinition @'
+    using System;
+
+    public class KoanAttribute : Attribute
+    {
+        public uint Position = UInt32.MaxValue;
+        public string Module = "_powershell";
+    }
 '@


### PR DESCRIPTION
﻿# PR Summary

Removing and reimporting PSKoans currently fails due to the KoanAttribute type being imported regardless of whether or not it's already been added to the session.

This is not an issue with the `Blank` class type as it is a PowerShell class, which are given random namespace prefixes to allow PS to "scope" the types internally to the module.

## Context

It's bad UX for a module to not be able to be imported again once it is removed.

## Changes

- Add a check when adding the `KoanAttribute` type, and skip the `Add-Type` if the type is already present in the session.
- Add a test to ensure that the module can be removed and re-imported cleanly.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
