### PR TITLE
Properly quote path argument to Start-Process

### DIFF
--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -59,25 +59,28 @@ function Show-Karma {
             Get-PSKoan @GetParams
         }
         'OpenFolder' {
-            $PSKoanLocationFullPath = $pscmdlet.GetUnresolvedProviderPathFromPSPath((Get-PSKoanLocation))
+            $KoanLocation = Get-PSKoanLocation
             Write-Verbose "Checking existence of koans folder"
-            if (-not (Test-Path $PSKoanLocationFullPath)) {
+            if (-not (Test-Path $KoanLocation)) {
                 Write-Verbose "Koans folder does not exist. Initiating full reset..."
                 Update-PSKoan -Confirm:$false
             }
+
+            # This can only throw if we were unable to create the path.
+            $KoanLocation = Resolve-Path -Path $KoanLocation
 
             Write-Verbose "Opening koans folder"
             $Editor = Get-PSKoanSetting -Name Editor
             if ($Editor -and (Get-Command -Name $Editor -ErrorAction SilentlyContinue)) {
                 $EditorSplat = @{
                     FilePath     = $Editor
-                    ArgumentList = $PSKoanLocationFullPath
+                    ArgumentList = '"{0}"' -f $KoanLocation
                     NoNewWindow  = $true
                 }
                 Start-Process @EditorSplat
             }
             else {
-                $PSKoanLocationFullPath | Invoke-Item
+                $KoanLocation | Invoke-Item
             }
         }
         default {

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -66,15 +66,12 @@ function Show-Karma {
                 Update-PSKoan -Confirm:$false
             }
 
-            # This can only throw if we were unable to create the path.
-            $KoanLocation = Resolve-Path -Path $KoanLocation
-
             Write-Verbose "Opening koans folder"
             $Editor = Get-PSKoanSetting -Name Editor
             if ($Editor -and (Get-Command -Name $Editor -ErrorAction SilentlyContinue)) {
                 $EditorSplat = @{
                     FilePath     = $Editor
-                    ArgumentList = '"{0}"' -f $KoanLocation
+                    ArgumentList = '"{0}"' -f (Resolve-Path $KoanLocation)
                     NoNewWindow  = $true
                 }
                 Start-Process @EditorSplat

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -207,11 +207,11 @@ Describe 'Show-Karma' {
                 }
 
                 It 'should pass a resolved path using quotes' {
-                    $Result.Path | Should -MatchExactly '"[^"]"'
+                    $Result.Path | Should -MatchExactly '"[^"]+"'
 
                     # Resolve-Path doesn't like embedded quotes
                     $Path = $Result.Path -replace '"'
-                    $Path | Should -BeExactly (Resolve-Path -Path $Path)
+                    $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
                 }
             }
 

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -186,20 +186,29 @@ Describe 'Show-Karma' {
             }
         }
 
-        Context 'With -Contemplate Switch' {
+        Context 'With -Meditate Switch' {
 
             Context 'With "code" Set as the Editor' {
                 BeforeAll {
                     Mock Get-Command { $true }
-                    Mock Start-Process { $FilePath }
-                    Set-PSKoanSetting -Name Editor -Value "code"
+                    Mock Start-Process {
+                        @{ Editor = $FilePath; Path = $ArgumentList }
+                    }
+                    Set-PSKoanSetting -Name Editor -Value 'code'
+
+                    $Result = Show-Karma -Contemplate
                 }
 
                 It 'should start VS Code with Start-Process' {
-                    Show-Karma -Contemplate | Should -Be 'code'
+                    $Result.Editor | Should -Be 'code'
 
                     Assert-MockCalled Get-Command -Times 1
                     Assert-MockCalled Start-Process -Times 1
+                }
+
+                It 'should pass a resolved path using quotes' {
+                    $Result.Path | Should -BeExactly (Resolve-Path $Result.Path)
+                    $Result.Path | Should -MatchExactly '"[^"]"'
                 }
             }
 
@@ -213,16 +222,14 @@ Describe 'Show-Karma' {
                 It 'should not produce output' {
                     Show-Karma -Meditate | Should -BeNullOrEmpty
                 }
+
                 It 'should open the koans directory with Invoke-Item' {
                     Assert-MockCalled Get-Command -Times 1 -ParameterFilter { $Name -eq "ascsadsa" }
                     Assert-MockCalled Invoke-Item -Times 1
                 }
             }
-        }
 
-        Context 'With -Meditate Switch' {
-
-            Context 'PSKoans directory does not exist' {
+            Context 'With Nonexistent KoanLocation' {
                 BeforeAll {
                     Mock Test-Path { $false }
                     Mock Update-PSKoan

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -207,8 +207,11 @@ Describe 'Show-Karma' {
                 }
 
                 It 'should pass a resolved path using quotes' {
-                    $Result.Path | Should -BeExactly (Resolve-Path $Result.Path)
                     $Result.Path | Should -MatchExactly '"[^"]"'
+
+                    # Resolve-Path doesn't like embedded quotes
+                    $Path = $Result.Path -replace '"'
+                    $Path | Should -BeExactly (Resolve-Path -Path $Path)
                 }
             }
 

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -206,12 +206,14 @@ Describe 'Show-Karma' {
                     Assert-MockCalled Start-Process -Times 1
                 }
 
-                It 'should pass a resolved path using quotes' {
-                    $Result.Path | Should -MatchExactly '"[^"]+"'
-
+                It 'should pass a resolved path' {
                     # Resolve-Path doesn't like embedded quotes
                     $Path = $Result.Path -replace '"'
                     $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
+                }
+
+                It 'should enclose the path in quotes' {
+                    $Result.Path | Should -MatchExactly '"[^"]+"'
                 }
             }
 


### PR DESCRIPTION
﻿# PR Summary

Start-Process doesn't pass through non-explicit quotes.
This unfortunately means paths with spaces get read as two arguments.

Fix is to properly insert explicit quotes to the argument first.

## Context

There's no reason not to support spaces in paths. This is 2019, c'mon. 😋 

Resolves #306 

## Changes

- Tidy up path resolution logic.
- Refactor Start-Process splat table to insert explicit quotes in the path argument.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
