### PR TITLE
Publish Commit Log as Markdown Table

### DIFF
--- a/Build/New-Changelog.ps1
+++ b/Build/New-Changelog.ps1
@@ -2,7 +2,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory, Position = 0)]
-    [ValidateScript( { Test-Path $_ })]
+    [ValidateScript( { Test-Path $_ -IsValid })]
     [string]
     $Path = "$env:SYSTEM_DEFAULTWORKINGDIRECTORY/Changelog.md",
 

--- a/Build/New-Changelog.ps1
+++ b/Build/New-Changelog.ps1
@@ -59,7 +59,7 @@ process {
                 )
             } |
             ConvertTo-Csv -Delimiter '|'
-    ) -replace '"'
+    ) -replace '"' -replace '^|$', '|'
 
     $MarkdownTable = @(
         # Header Row Only

--- a/Build/New-Changelog.ps1
+++ b/Build/New-Changelog.ps1
@@ -1,0 +1,74 @@
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateScript( { Test-Path $_ })]
+    [string]
+    $Path = "$env:SYSTEM_DEFAULTWORKINGDIRECTORY/Changelog.md",
+
+    [Parameter(Position = 1)]
+    [ValidatePattern('[a-f0-9]{6,40}|v?(\d+\.)+\d+(-\w+\d+)?')]
+    [string]
+    $CommitID = (git tag | Select-Object -Last 1),
+
+    [Parameter(Mandatory)]
+    [string]
+    $ApiKey
+)
+
+begin {
+    Invoke-RestMethod -SessionVariable AuthSession -Uri https://api.github.com/ -Headers @{
+        Authorization = "token $ApiKey"
+    } |
+        Out-String |
+        Write-Verbose
+}
+process {
+    $Args = @(
+        '--no-pager'
+        'log'
+        '--first-parent'
+        "$CommitID..HEAD"
+        '--format="%H~%aN~%aE~%s"'
+        '--'
+        '.'
+        '":(exclude)*.md"'
+    )
+    $Commits = & git @args |
+        ConvertFrom-Csv -Delimiter '~' -Header Hash, Name, Email, Subject |
+        Group-Object -Property Name
+
+    $CsvString = $(
+        $Commits |
+            ForEach-Object {
+                $result = Invoke-RestMethod -Uri "https://api.github.com/search/users?q=$($_.Group[0].Email)+in:email" -WebSession $AuthSession
+                $Name = if ($result.total_count -ne 0) { $result.items[0].login }
+
+                $_.Group | Select-Object -Property @(
+                    @{ Name = 'Hash'; Expression = { $_.Hash.Substring(0, 7) } }
+                    @{
+                        Name       = 'Name'
+                        Expression = {
+                            $(
+                                $_.Name
+                                if ($Name) { "(@$Name)" }
+                            ) -join ' '
+                        }
+                    }
+                    'Subject'
+                )
+            } |
+            ConvertTo-Csv -Delimiter '|'
+    ) -replace '"'
+
+    $MarkdownTable = @(
+        # Header Row Only
+        $CsvString | Select-Object -First 1
+        # Adding Markdown table column alignments
+        "| :--: | :--- | :--- |"
+        # Data Rows
+        $CsvString | Select-Object -Skip 1
+    )
+
+    $MarkdownTable | Set-Content -Path $Path
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Changelog'
     inputs:
-      path: '$(System.DefaultWorkingDirectory)/CommitLog.md'
+      path: '$(System.DefaultWorkingDirectory)/Changelog.md'
       artifact: Changelog.md
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,10 +67,7 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: ./Deploy/Publish.ps1
-      arguments: |
-        -Key 'filesystem'
-        -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
-        -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
+      arguments: -Key 'filesystem' -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem' -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
 
       errorActionPreference: 'stop'
       failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,6 @@ jobs:
   pool:
     vmImage: ubuntu-latest
 
-
   steps:
   - task: PowerShell@2
     displayName: 'Create Changelog'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,30 +67,20 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: ./Deploy/Publish.ps1
-      arguments: -Key 'filesystem' -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem' -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
+      arguments: |
+        -Key 'filesystem'
+        -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
+        -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
 
       errorActionPreference: 'stop'
       failOnStderr: true
       pwsh: true
-
-  - task: PowerShell@2
-    displayName: 'Create Changelog'
-    inputs:
-      targetType: 'filepath'
-      filePath: ./Build/New-Changelog.ps1
-      arguments: -Path '$(System.DefaultWorkingDirectory)/Changelog.md' -ApiKey $(GithubApiKey) -Verbose
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Module Nupkg'
     inputs:
       path: '$(NupkgPath)'
       artifact: PSKoans.nupkg
-
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish Changelog'
-    inputs:
-      path: '$(System.DefaultWorkingDirectory)/Changelog.md'
-      artifact: Changelog
 
   - task: PowerShell@2
     displayName: 'Deploy to PowerShell Gallery'
@@ -104,3 +94,28 @@ jobs:
       errorActionPreference: 'stop'
       failOnStderr: true
       pwsh: true
+
+- job: GenerateChangelog
+  displayName: "Publish Changelog"
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
+  dependsOn:
+    - Linux
+    - Windows
+    - MacOS
+  pool:
+    vmImage: ubuntu-latest
+
+
+  steps:
+  - task: PowerShell@2
+    displayName: 'Create Changelog'
+    inputs:
+      targetType: 'filepath'
+      filePath: ./Build/New-Changelog.ps1
+      arguments: -Path '$(System.DefaultWorkingDirectory)/Changelog.md' -ApiKey $(GithubApiKey) -Verbose
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Changelog'
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/Changelog.md'
+      artifact: Changelog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
     inputs:
       targetType: 'filepath'
       filePath: ./Build/New-Changelog.ps1
-      arguments: -Path '$(System.DefaultWorkingDirectory)/Changelog.md' -ApiKey $(GithubApiKey)
+      arguments: -Path '$(System.DefaultWorkingDirectory)/Changelog.md' -ApiKey $(GithubApiKey) -Verbose
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Module Nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,18 +66,31 @@ jobs:
     displayName: 'Deploy to FileSystem'
     inputs:
       targetType: 'filePath'
-      arguments: -Key 'filesystem' -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem' -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
       filePath: ./Deploy/Publish.ps1
+      arguments: -Key 'filesystem' -Path '$(System.DefaultWorkingDirectory)/Deploy/FileSystem' -OutputDirectory '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
 
       errorActionPreference: 'stop'
       failOnStderr: true
       pwsh: true
+
+  - task: PowerShell@2
+    displayName: 'Create Changelog'
+    inputs:
+      targetType: 'filepath'
+      filePath: ./Build/New-Changelog.ps1
+      arguments: -Path '$(System.DefaultWorkingDirectory)/Changelog.md' -ApiKey $(GithubApiKey)
 
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Module Nupkg'
     inputs:
       path: '$(NupkgPath)'
       artifact: PSKoans.nupkg
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Changelog'
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/CommitLog.md'
+      artifact: Changelog.md
 
   - task: PowerShell@2
     displayName: 'Deploy to PowerShell Gallery'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
     displayName: 'Publish Changelog'
     inputs:
       path: '$(System.DefaultWorkingDirectory)/Changelog.md'
-      artifact: Changelog.md
+      artifact: Changelog
 
   - task: PowerShell@2
     displayName: 'Deploy to PowerShell Gallery'


### PR DESCRIPTION
﻿# PR Summary

I don't wanna manually edit the entire changelog table together every time, so I'll have CI do most of it for me.

## Context

Tbh this is more of a "why not, this sounds cool at 11PM" kind of idea than anything, but... hey, why not give it a looksee.

## Changes

- Add `New-Changelog` script to the `Build` folder
- Add CI steps to create the changelog as an MD file and publish it as a pipeline artifact.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
