### PR TITLE
Reset-PSKoan: Improve handling for missing topics

### DIFF
--- a/PSKoans/Public/Reset-PSKoan.ps1
+++ b/PSKoans/Public/Reset-PSKoan.ps1
@@ -37,8 +37,8 @@ function Reset-PSKoan {
     }
     switch ($pscmdlet.ParameterSetName) {
         'IncludeModule' { $GetParams['IncludeModule'] = $IncludeModule }
-        'ModuleOnly'    { $GetParams['Module'] = $Module }
-        { $Topic }      { $GetParams['Topic'] = $Topic }
+        'ModuleOnly' { $GetParams['Module'] = $Module }
+        { $Topic } { $GetParams['Topic'] = $Topic }
     }
     $ModuleKoanList = Get-PSKoan @GetParams | Group-Object Topic -AsHashtable -AsString
 
@@ -46,7 +46,7 @@ function Reset-PSKoan {
     $UserKoanList = Get-PSKoan @GetParams | Group-Object Topic -AsHashtable -AsString
 
     if (-not $UserKoanList) {
-        $UserKoanList = @{}
+        $UserKoanList = @{ }
     }
 
     if (-not $ModuleKoanList) {
@@ -62,14 +62,19 @@ function Reset-PSKoan {
 
     foreach ($moduleTopic in $ModuleKoanList.Keys) {
         if (-not $UserKoanList.ContainsKey($moduleTopic)) {
-            $ErrorDetails = @{
-                ExceptionType    = 'System.Management.Automation.ItemNotFoundException'
-                ExceptionMessage = 'No matching topic {0} in the user Koan location' -f $moduleTopic
-                ErrorId          = 'PSKoans.UserTopicNotFound'
-                ErrorCategory    = 'ObjectNotFound'
-                TargetObject     = $moduleTopic
+            if ($PSCmdlet.ShouldProcess($moduleTopic, 'Add new topic to PSKoans library')) {
+                Update-PSKoan -Topic $moduleTopic -Confirm:$false
             }
-            Write-Error -ErrorRecord (New-PSKoanErrorRecord @ErrorDetails)
+            else {
+                $ErrorDetails = @{
+                    ExceptionType    = 'System.Management.Automation.ItemNotFoundException'
+                    ExceptionMessage = 'No matching topic {0} in the user Koan location' -f $moduleTopic
+                    ErrorId          = 'PSKoans.UserTopicNotFound'
+                    ErrorCategory    = 'ObjectNotFound'
+                    TargetObject     = $moduleTopic
+                }
+                Write-Error -ErrorRecord (New-PSKoanErrorRecord @ErrorDetails)
+            }
 
             continue
         }

--- a/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
+++ b/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
@@ -17,11 +17,11 @@ InModuleScope PSKoans {
                 Join-Path -Path $TestDrive -ChildPath 'PSKoans'
             }
             Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' } -MockWith {
-                 [PSCustomObject]@{
-                     Topic        = 'AboutSomething'
-                     Path         = Join-Path -Path $TestDrive -ChildPath 'Module\Group\AboutSomething.Koans.ps1'
-                     RelativePath = 'Group\AboutSomething.Koans.ps1'
-                 }
+                [PSCustomObject]@{
+                    Topic        = 'AboutSomething'
+                    Path         = Join-Path -Path $TestDrive -ChildPath 'Module\Group\AboutSomething.Koans.ps1'
+                    RelativePath = 'Group\AboutSomething.Koans.ps1'
+                }
             }
             New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Module\Group') -ItemType Directory
             New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'PSKoans\Group') -ItemType Directory
@@ -105,10 +105,13 @@ InModuleScope PSKoans {
         Context 'User file does not exist' {
             BeforeAll {
                 Mock Get-PSKoan -ParameterFilter { $Scope -eq 'User' }
+                Mock Update-PSKoan -ParameterFilter { $Topic -eq 'DoesNotExist' }
             }
 
-            It 'When the topic does not exist in the user location, write an error' {
-                { Reset-PSKoan -Topic DoesNotExist -ErrorAction Stop @defaultParams } | Should -Throw -ErrorId PSKoans.UserTopicNotFound
+            It 'When the topic does not exist in the user location, call Update-PSKoan' {
+                Reset-PSKoan -Topic DoesNotExist -ErrorAction Stop @defaultParams
+
+                Assert-MockCalled Update-PSKoan -ParameterFilter { $Topic -eq 'DoesNotExist' }
             }
         }
 

--- a/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
+++ b/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
@@ -104,14 +104,25 @@ InModuleScope PSKoans {
 
         Context 'User file does not exist' {
             BeforeAll {
+                New-Item "$TestDrive/DoesNotExist.Koans.ps1" -ItemType File > $null
                 Mock Get-PSKoan -ParameterFilter { $Scope -eq 'User' }
-                Mock Update-PSKoan -ParameterFilter { $Topic -eq 'DoesNotExist' }
+                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' } {
+                    [PSCustomObject]@{
+                        Topic        = $Topic
+                        Module       = '_powershell'
+                        Position     = 101
+                        Path         = "$TestDrive/DoesNotExist.Koans.ps1"
+                        RelativePath = 'DoesNotExist.Koans.ps1'
+                        PSTypeName   = 'PSKoans.KoanInfo'
+                    }
+                }
+                Mock Update-PSKoan
             }
 
             It 'When the topic does not exist in the user location, call Update-PSKoan' {
                 Reset-PSKoan -Topic DoesNotExist -ErrorAction Stop @defaultParams
 
-                Assert-MockCalled Update-PSKoan -ParameterFilter { $Topic -eq 'DoesNotExist' }
+                Assert-MockCalled Update-PSKoan -Times 1
             }
         }
 


### PR DESCRIPTION
﻿# PR Summary

Added some handling to just add the missing topics with `Update-PSKoan` instead of emitting errors.
Error may still be emitted if the user gives a negative response to that ShouldProcess prompt.

## Context

✨ Resolves #311 ✨ 

## Changes

- Added additional ShouldProcess check to determined whether to throw the error. If user agrees to add the new topic, `Update-PSKoan` is called for that topic to restore the file. Otherwise, emit an error.

### TODO

- [ ] Add test(s) to ensure the functionality works as expected.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.

@indented-automation could you look over this when you have a brief moment? 💖 😊 