### PR TITLE
Changelog - Leave commits in order

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
 
 - job: GenerateChangelog
   displayName: "Publish Changelog"
-  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
   dependsOn:
     - Linux
     - Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
 
 - job: GenerateChangelog
   displayName: "Publish Changelog"
-  #condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
   dependsOn:
     - Linux
     - Windows


### PR DESCRIPTION
﻿# PR Summary

Having commits grouped by name is nice, but it's better to have it just in order I think.

## Changes

- Update GH username fetching to retry after a bit on failure.
- Avoid grouping items, so we don't get the semi-sorting behaviour.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
