### PR TITLE
AboutAssertions - Avoid Casting [Blank] to [bool]

### DIFF
--- a/PSKoans/Koans/Introduction/AboutAssertions.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutAssertions.Koans.ps1
@@ -14,11 +14,11 @@ param()
     This is where the fun begins! Each koan contains an example designed
     to teach you a lesson about PowerShell. If you execute the program
     defined in this project, you will get a message that the koan below
-    has failed. Your job is to fill in the blanks (the __, $__, FILL_ME_IN,
-    or $FILL_ME_IN symbols) to make it pass. Once you make the change,
-    re-run the program to make sure the koan passes, and continue on to the
-    next failing koan. With each passing koan, you'll learn more about
-    PowerShell, and add another weapon to your PowerShell scripting arsenal.
+    has failed. Your job is to fill in the blanks (the __ or ____ symbols)
+    to make it pass. Once you make the change, call Show-Karma to make sure
+    the koan passes, and continue on to the next failing koan.
+    With each passing koan, you'll learn more about PowerShell, and add
+    another tool to your PowerShell scripting belt.
 #>
 Describe 'Equality' {
 

--- a/PSKoans/Koans/Introduction/AboutAssertions.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutAssertions.Koans.ps1
@@ -30,7 +30,7 @@ Describe 'Equality' {
     It 'expects you to fill in values' {
         # Initiative will be rewarded.
         __ | Should -Be (1 + 2)
-        __ + 5 -eq 10 | Should -BeTrue
+        __ + 5 | Should -Be 10
     }
 
     It 'sets the expectations' {
@@ -45,6 +45,6 @@ Describe 'Equality' {
 
     It 'demands balance' {
         # Both sides of the scale must be of equal measure.
-        __ + 2 -eq 3 | Should -BeTrue
+        __ + 2 | Should -Be 3
     }
 }


### PR DESCRIPTION
﻿# PR Summary

PS's built-in boolean-casting behaviour cannot be overridden for reference types casting to bool, so any assertion that results in `$blank | Should -BeTrue` where `$blank` is an instance of `[Blank]` (obtained usually from `Get-Blank` / `__` / `____`) will automatically pass.

The usual fix is to avoid framing assertions in this way.

## Context

Resolves #315 

## Changes

- Reframe affected assertions to avoid the casting behaviour.
- Update parts of the intstruction comments.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
