### PR TITLE
:memo: Fix incorrect number in number check

### DIFF
--- a/PSKoans/Koans/Introduction/AboutBinary.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutBinary.Koans.ps1
@@ -126,7 +126,7 @@ Describe "Binary conversion" {
 
         # Replace __ with the binary value of 14
         $Binary = "__"
-        $Value = 7
+        $Value = 14
         $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
 
         # Replace __ with the binary value of 103


### PR DESCRIPTION
Update the number check to match what is in the comment preceding it. Otherwise it is evaluating the wrong question and is confusing, plus the original number would be a repeat of a previous check.

﻿# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

<!-- List any and all changes here, in bullet point form. -->
* Changed number check from `7` to `14` to reflect the actual question and not be a repeat.
## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
