### PR TITLE
Change order of input array to match expected output

### DIFF
--- a/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
@@ -156,8 +156,8 @@ Describe 'Switch' {
 
         It 'will process each element of arrays' {
             $Array = @(
-                __
                 4
+                __
             )
 
             $Result = switch ($Array) {


### PR DESCRIPTION
# PR Summary

Fixes #333 

Reverses order of input array in order to match expected output.

## Context

Input array did not produce expected output.

## Changes

- Reversed order of items in input array

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
