### PR TITLE
Add "Open File" Feature

### DIFF
--- a/PSKoans/Public/Get-Karma.ps1
+++ b/PSKoans/Public/Get-Karma.ps1
@@ -110,9 +110,10 @@
                     KoansPassed    = $KoansPassed
                     TotalKoans     = $TotalKoans
                     CurrentTopic   = [PSCustomObject]@{
-                        Name      = $KoanFile.Topic
-                        Completed = $PesterTests.PassedCount
-                        Total     = $PesterTests.TotalCount
+                        Name        = $KoanFile.Topic
+                        Completed   = $PesterTests.PassedCount
+                        Total       = $PesterTests.TotalCount
+                        CurrentLine = ($NextKoanFailed.StackTrace -split '\r?\n')[1] -replace ':.+'
                     }
                     Results        = $PesterTests.TestResult
                     RequestedTopic = $Topic

--- a/PSKoans/Public/Get-Karma.ps1
+++ b/PSKoans/Public/Get-Karma.ps1
@@ -32,6 +32,7 @@
         'ModuleOnly' { $GetParams['Module'] = $Module }
         { $Topic } { $GetParams['Topic'] = $Topic }
     }
+
     switch ($PSCmdlet.ParameterSetName) {
         'ListKoans' {
             Get-PSKoan @GetParams

--- a/PSKoans/Public/Get-PSKoan.ps1
+++ b/PSKoans/Public/Get-PSKoan.ps1
@@ -32,7 +32,16 @@ function Get-PSKoan {
     )
 
     $ParentPath = switch ($Scope) {
-        'User'   { Get-PSKoanLocation }
+        'User' {
+            $KoanLocation = Get-PSKoanLocation
+            Write-Verbose "Checking existence of koans folder"
+            if (-not (Test-Path $KoanLocation)) {
+                Write-Verbose "Koans folder does not exist. Initiating full reset..."
+                Update-PSKoan -Confirm:$false
+            }
+
+            $KoanLocation
+        }
         'Module' { Join-Path -Path $script:ModuleRoot -ChildPath 'Koans' }
     }
 

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -97,19 +97,17 @@ function Show-Karma {
             $FilePath = (Get-PSKoan -Topic $Results.CurrentTopic.Name -Scope User).Path
             $LineNumber = $Results.CurrentTopic.CurrentLine
 
-            switch ($Editor) {
+            $Arguments = switch ($Editor) {
                 { $_ -in 'code', 'code-insiders' } {
-                    $Arguments = @(
-                        '--goto'
-                        '"{0}":{1}' -f $FilePath, $LineNumber
-                        '--reuse-window'
-                    )
+                    '--goto'
+                    '"{0}":{1}' -f (Resolve-Path $FilePath), $LineNumber
+                    '--reuse-window'
                 }
                 atom {
-                    $Arguments = '"{0}":{1}' -f $FilePath, $LineNumber
+                    '"{0}":{1}' -f (Resolve-Path $FilePath), $LineNumber
                 }
                 default {
-                    $Arguments = '"{0}"' -f $FilePath
+                    '"{0}"' -f (Resolve-Path $FilePath)
                 }
             }
 

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -163,4 +163,3 @@ function Show-Karma {
         Show-MeditationPrompt @Params
     }
 }
-}

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -120,46 +120,47 @@ function Show-Karma {
                 Invoke-Item -Path $FilePath
             }
         }
-    }
-    default {
-        if ($ClearScreen) {
-            Clear-Host
-        }
 
-        Show-MeditationPrompt -Greeting
-
-        try {
-            $Results = Get-Karma @GetParams
-        }
-        catch {
-            $PSCmdlet.ThrowTerminatingError($_)
-        }
-
-        if ($Results.Complete) {
-            $Params = @{
-                KoansPassed    = $Results.KoansPassed
-                TotalKoans     = $Results.TotalKoans
-                RequestedTopic = $Topic
-                Complete       = $Results.Complete
-            }
-        }
-        else {
-            $Params = @{
-                DescribeName   = $Results.Describe
-                ItName         = $Results.It
-                Expectation    = $Results.Expectation
-                Meditation     = $Results.Meditation
-                KoansPassed    = $Results.KoansPassed
-                TotalKoans     = $Results.TotalKoans
-                CurrentTopic   = $Results.CurrentTopic
-                RequestedTopic = $Topic
+        default {
+            if ($ClearScreen) {
+                Clear-Host
             }
 
-            if ($Detailed) {
-                $Params.Add('Results', $Results.Results)
-            }
-        }
+            Show-MeditationPrompt -Greeting
 
-        Show-MeditationPrompt @Params
+            try {
+                $Results = Get-Karma @GetParams
+            }
+            catch {
+                $PSCmdlet.ThrowTerminatingError($_)
+            }
+
+            if ($Results.Complete) {
+                $Params = @{
+                    KoansPassed    = $Results.KoansPassed
+                    TotalKoans     = $Results.TotalKoans
+                    RequestedTopic = $Topic
+                    Complete       = $Results.Complete
+                }
+            }
+            else {
+                $Params = @{
+                    DescribeName   = $Results.Describe
+                    ItName         = $Results.It
+                    Expectation    = $Results.Expectation
+                    Meditation     = $Results.Meditation
+                    KoansPassed    = $Results.KoansPassed
+                    TotalKoans     = $Results.TotalKoans
+                    CurrentTopic   = $Results.CurrentTopic
+                    RequestedTopic = $Topic
+                }
+
+                if ($Detailed) {
+                    $Params.Add('Results', $Results.Results)
+                }
+            }
+
+            Show-MeditationPrompt @Params
+        }
     }
 }

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -109,7 +109,7 @@ function Show-Karma {
                     $Arguments = '"{0}":{1}' -f $FilePath, $LineNumber
                 }
                 default {
-                    $Arguments = "{0}" -f $FilePath
+                    $Arguments = '"{0}"' -f $FilePath
                 }
             }
 

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -94,7 +94,7 @@ function Show-Karma {
             }
 
             $Editor = Get-PSKoanSetting -Name Editor
-            $FilePath = Get-PSKoan -Topic $Results.CurrentTopic.Name -Scope User | Select-Object -ExpandProperty Path
+            $FilePath = (Get-PSKoan -Topic $Results.CurrentTopic.Name -Scope User).Path
             $LineNumber = $Results.CurrentTopic.CurrentLine
 
             switch ($Editor) {

--- a/docs/Show-Karma.md
+++ b/docs/Show-Karma.md
@@ -32,9 +32,14 @@ Show-Karma [-Topic <String[]>] -Module <String[]> [-ClearScreen] [-Detailed] [<C
 Show-Karma [-Topic <String[]>] [-Module <String[]>] [-List] [-ClearScreen] [<CommonParameters>]
 ```
 
-### OpenFolder
+### OpenFile
 ```
 Show-Karma [-Contemplate] [-ClearScreen] [<CommonParameters>]
+```
+
+### OpenFolder
+```
+Show-Karma [-Library] [-ClearScreen] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,9 +59,10 @@ Assesses the koan lessons, and displays the meditation prompt with the results.
 Show-Karma -Contemplate
 ```
 
-Opens the user's koans folder, housed in `$home\PSKoans`.
-If VS Code is in `$env:PATH`, opens VS Code to the workspace location.
-Otherwise, the folder is opened in a file explorer.
+Opens the current koan file in the editor specified by the `Editor` setting.
+Use [`Set-PSKoanSetting`](./Set-PSKoanSetting.md) to change the editor used.
+
+If a known editor (`code`, `code-insiders`, or `atom`) is used, PSKoans will pass along line information as well.
 
 ## PARAMETERS
 
@@ -84,7 +90,7 @@ If you have VS Code Insiders installed, you can set `$env:PSKoans_EditorPreferen
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: OpenFolder
+Parameter Sets: OpenFile
 Aliases: Meditate
 
 Required: True
@@ -117,6 +123,25 @@ Show Karma for the default PowerShell Koans as well as Koans for the specified m
 Type: String[]
 Parameter Sets: IncludeModule
 Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Library
+Opens the current `KoanLocation` folder in the preferred editor.
+To set the preferred editor, use [`Set-PSKoanSetting`](./Set-PSKoanSetting.md).
+
+If the preferred editor cannot be found or the setting is cleared, the folder will be opened in the default handler.
+This should be Windows Explorer on Windows, Finder on Mac, etc.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: OpenFolder
+Aliases: OpenFolder
 
 Required: True
 Position: Named


### PR DESCRIPTION
# PR Summary

Add functionality for opening current koan _file_ instead of just the overall PSKoanLocation from `Show-Karma`

## Context

This PR supersedes #317, all credit for initial idea goes to @arefg -- thank you so much for the work you put in on this already, it really made this a hundred times easier. 😊 💖 

## Changes

- Moves the "open koan folder" functionality to `-Library` switch.
- Modifies `-Contemplate` switch to work as an "open current file in the set editor" with capability to recognise `code` and `code-insiders` as well as `atom` and pass correct arguments for these editors to also go to the relevant line in the file.
- Updates tests to verify new functionality.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
