### PR TITLE
Implement simple current topic information cache

### DIFF
--- a/PSKoans/PSKoans.psm1
+++ b/PSKoans/PSKoans.psm1
@@ -20,6 +20,8 @@ $script:DefaultSettings = @{
     Editor       = 'code'
 }
 
+[hashtable] $script:CurrentTopic = $null
+
 #region SupportingClasses
 
 Get-ChildItem -Path "$PSScriptRoot/Classes" | ForEach-Object {

--- a/PSKoans/Public/Get-Karma.ps1
+++ b/PSKoans/Public/Get-Karma.ps1
@@ -102,6 +102,13 @@
                     Where-Object Result -eq 'Failed' |
                     Select-Object -First 1
 
+                $script:CurrentTopic = @{
+                    Name        = $KoanFile.Topic
+                    Completed   = $PesterTests.PassedCount
+                    Total       = $PesterTests.TotalCount
+                    CurrentLine = ($NextKoanFailed.StackTrace -split '\r?\n')[1] -replace ':.+'
+                }
+
                 [PSCustomObject]@{
                     PSTypeName     = 'PSKoans.Result'
                     Describe       = $NextKoanFailed.Describe
@@ -110,12 +117,7 @@
                     Meditation     = $NextKoanFailed.StackTrace
                     KoansPassed    = $KoansPassed
                     TotalKoans     = $TotalKoans
-                    CurrentTopic   = [PSCustomObject]@{
-                        Name        = $KoanFile.Topic
-                        Completed   = $PesterTests.PassedCount
-                        Total       = $PesterTests.TotalCount
-                        CurrentLine = ($NextKoanFailed.StackTrace -split '\r?\n')[1] -replace ':.+'
-                    }
+                    CurrentTopic   = [PSCustomObject]$script:CurrentTopic
                     Results        = $PesterTests.TestResult
                     RequestedTopic = $Topic
                 }

--- a/Tests/Functions/Public/Get-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Get-Karma.Tests.ps1
@@ -37,6 +37,12 @@ InModuleScope 'PSKoans' {
             It 'should Invoke-Pester on koans until it fails a test' {
                 Assert-MockCalled Invoke-Koan -Times 1
             }
+
+            It 'should populate the $script:CurrentTopic variable' {
+                $script:CurrentTopic | Should -BeOfType [hashtable]
+                $script:CurrentTopic.Count | Should -Be 4
+                @('Name', 'Completed', 'Total', 'CurrentLine') | Should -BeIn $script:CurrentTopic.Keys
+            }
         }
 
         Context 'With Nonexistent Koans Folder / No Koans Found' {


### PR DESCRIPTION
# PR Summary

Adds functionality to `Get-Karma` to set a transient module-scoped variable containing information on the current topic (topic, current line, completion, etc.)

This can then be used in `Show-Karma -Contemplate` to quickly open the editor without the need to call `Get-Karma` all over again. The value is then cleared from the variable, so that subsequent calls to `Show-Karma -Contemplate` aren't blindly assuming that no progress has been made.

## Context

Resolves #351 

## Changes

- Store `CurrentTopic` data in `$script:CurrentTopic` module-scoped variable just before `Get-Karma` submits its output
- Reuse this information when it is available in `Show-Karma -Contemplate` and then immediately clear it.
- Updated tests to expect this behaviour.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
