### PR TITLE
Use integers instead of strings in the `-gt and -lt` within the AboutComparison Koan

### DIFF
--- a/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
@@ -101,11 +101,14 @@ Describe 'Comparison Operators' {
         }
 
         It 'will often return more than one item from arrays' {
-            $Array = '1', '5', '10', '15', '20', '25', '30'
+            $Array = 1, 5, 10, 15, 20, 25, 30
 
+            $NewArray = @(
+                __
+                __
+            )
+            $NewArray | Should -Be ($Array -lt 10)
             __ | Should -Be ($Array -gt 25)
-            @('__', '__') | Should -Be ($Array -lt 10)
-
         }
     }
 


### PR DESCRIPTION
# PR Summary

This PR should fix the misunderstanding described in #353
<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #353 
Resolves #353 

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

See #353 

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

* Replaced array of strings with array of int
* Added `$NewArray` to hold answer

<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
