### PR TITLE
Bugfix358 - Instantiate Stings and Numbers in AboutArrays

### DIFF
--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -261,12 +261,12 @@ Describe 'Arrays' {
         $____ -eq $Numbers.Contains(3) | Should -BeTrue
 
         # The Contains method is case sensitive for arrays containing strings.
-
+        $Strings = 'first', 'second', 'third'
         $____ -eq $Strings.Contains('first') | Should -BeTrue
         $____ -eq $Strings.Contains('First') | Should -BeTrue
-
+        
         # PowerShell's -contains operator is not case sensitive.
-        $Strings = 'first', 'second', 'third'
+        
         $Strings -contains '____' | Should -BeTrue
         $Strings -contains '____' | Should -BeTrue
     }

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -266,7 +266,6 @@ Describe 'Arrays' {
         $____ -eq $Strings.Contains('First') | Should -BeTrue
         
         # PowerShell's -contains operator is not case sensitive.
-        
         $Strings -contains '____' | Should -BeTrue
         $Strings -contains '____' | Should -BeTrue
     }

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -264,7 +264,6 @@ Describe 'Arrays' {
         $Strings = 'first', 'second', 'third'
         $____ -eq $Strings.Contains('first') | Should -BeTrue
         $____ -eq $Strings.Contains('First') | Should -BeTrue
-        
         # PowerShell's -contains operator is not case sensitive.
         $Strings -contains '____' | Should -BeTrue
         $Strings -contains '____' | Should -BeTrue

--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -257,7 +257,7 @@ Describe 'Arrays' {
 
             For example, each array has a Contains method.
         #>
-
+        $Numbers = 1, 2, 3, 4
         $____ -eq $Numbers.Contains(3) | Should -BeTrue
 
         # The Contains method is case sensitive for arrays containing strings.
@@ -266,7 +266,7 @@ Describe 'Arrays' {
         $____ -eq $Strings.Contains('First') | Should -BeTrue
 
         # PowerShell's -contains operator is not case sensitive.
-
+        $Strings = 'first', 'second', 'third'
         $Strings -contains '____' | Should -BeTrue
         $Strings -contains '____' | Should -BeTrue
     }


### PR DESCRIPTION
# PR Summary
Fixes #358 

This fixes the issue where Strings and Numbers are null in the It block "allows you to check if something is contained within it" which are created in the It block before.
<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:



For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

<!-- List any and all changes here, in bullet point form. -->

- Create $number and $strings in It block "allows you to check if something is contained within it"

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
