### PR TITLE
(#298) Refactor Show-Advice Tests

### DIFF
--- a/Tests/Functions/Public/Show-Advice.Tests.ps1
+++ b/Tests/Functions/Public/Show-Advice.Tests.ps1
@@ -3,13 +3,13 @@
 InModuleScope 'PSKoans' {
     Describe "Show-Advice" {
 
-        BeforeAll{
-            Mock Write-ConsoleLine { } 
+        BeforeAll {
+            Mock Write-ConsoleLine { }
             # Exporting incorrect advices to the folder
             $AdviceFolder = $script:ModuleRoot | Join-Path -ChildPath 'Data/Advice'
             $AdviceObject = Get-ChildItem -Path $AdviceFolder -Recurse -File -Filter "*.Advice.json"
             $RandomAdvicesFilePaths = ($AdviceObject | Get-Random -Count 3).FullName
-            $Backup = $RandomAdvicesFilePaths | ForEach-Object {Get-Content $_ | ConvertFrom-Json}
+            $Backup = $RandomAdvicesFilePaths | ForEach-Object { Get-Content $_ | ConvertFrom-Json }
         }
 
         Context "Behaviour of Parameter-less Calls" {
@@ -22,7 +22,7 @@ InModuleScope 'PSKoans' {
             It "calls Write-ConsoleLine with only the display string" {
                 Assert-MockCalled -CommandName Write-ConsoleLine -ParameterFilter { $null -ne $Title } -Times 1
             }
-            
+
             It "outputs nothing to the pipeline" {
                 $result | Should -BeNullOrEmpty
             }
@@ -31,12 +31,12 @@ InModuleScope 'PSKoans' {
         Context "Behaviour with -Name Parameter" {
 
             It "should call Write-ConsoleLine with normal parameters" {
-                Show-Advice -Name "Profile" 
+                Show-Advice -Name "Profile"
                 Assert-MockCalled -CommandName Write-ConsoleLine -ParameterFilter { $null -ne $Title }
             }
 
             It "should call Write-ConsoleLine without parameters" {
-                Show-Advice -Name "Profile" 
+                Show-Advice -Name "Profile"
                 Assert-MockCalled -CommandName Write-ConsoleLine -ParameterFilter { $null -eq $Title }
             }
 
@@ -44,38 +44,44 @@ InModuleScope 'PSKoans' {
                 $message = "Could not find any Advice files matching the specified Name: ThisDoesntExist"
                 { Show-Advice -Name "ThisDoesntExist" -ErrorAction Stop } | Should -Throw -ExpectedMessage $Message
             }
-
-            # Creating incorrect Advice
-            $IncorrectObjectsData = @(
-                @{
-                    NotTitle = "Fake title"
-                    NotContent = @(1..4 | ForEach-Object {"Fake line $_"})
-                },
-                @{
-                    Content = @(1..4 | ForEach-Object {"Fake line $_"})
-                },
-                @{
-                    Title = "Fake title"
-                }
-            )
-            for ($i = 0; $i -lt 3; $i++) {
-                $IncorrectObjectsData[$i] | ConvertTo-Json | Out-File $RandomAdvicesFilePaths[$i]
-            }
-            
-            It "should throw an error if the requested file's format is not correct" {
-                for ($i = 0; $i -lt 3; $i++) {
-                    $AdviceName = (Get-Item $RandomAdvicesFilePaths[$i]).BaseName -replace('^(.*)(?:.Advice)','$1')
-                    $Message = "Could not find Title and/or Content elements for Advice file: {0}" -f $AdviceName
-                    { Show-Advice -Name $AdviceName -ErrorAction Stop } | Should -Throw -ExpectedMessage $Message
-                }
-            }
-
         }
 
-        AfterAll{
-            for ($i = 0; $i -lt 3; $i++) {
-                Set-Content -Path ((Get-Item $RandomAdvicesFilePaths[$i]).FullName) -Value ($Backup[$i] | ConvertTo-Json)
+        Context 'Behaviour with malformed advice files' {
+
+            BeforeAll {
+                $MalformedAdviceCases = @(
+                    @{
+                        Json = @{
+                            NotTitle   = "Fake title"
+                            NotContent = @(1..4 | ForEach-Object { "Fake line $_" })
+                        } | ConvertTo-Json
+                    }
+                    @{
+                        Json = @{
+                            Content = @(1..4 | ForEach-Object { "Fake line $_" })
+                        } | ConvertTo-Json
+                    }
+                    @{
+                        Json = @{
+                            Title = "Fake title"
+                        } | ConvertTo-Json
+                    }
+                )
+
+                $GetContentResult = [string]::Empty
+
+                Mock Get-Content -MockWith { $GetContentResult }
+                Mock Get-ChildItem -MockWith { [PSCustomObject]@{ PSPath = "DummyPath" } }
+            }
+
+            It "should throw an error if the requested file's format is not correct" -TestCases $MalformedAdviceCases {
+                param($Json)
+
+                $GetContentResult = $Json
+                $AdviceName = "TestAdvice"
+                $Message = "Could not find Title and/or Content elements for Advice file: {0}" -f $AdviceName
+                { Show-Advice -Name $AdviceName -ErrorAction Stop } | Should -Throw -ExpectedMessage $Message
             }
         }
-    }   
+    }
 }


### PR DESCRIPTION
# PR Summary

Use mocks instead of modifying the filesystem & use test cases instead of manual `for` loops.

## Context

Resolves #298 

## Changes

- Move malformed JSON tests to a new Context
- Mock Get-Content and Get-ChildItem so that we can just return the JSON without editing files on the hard drive
- Use TestCases to go through the different variants of invalid json rather than a `for` loop.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
