### PR TITLE
Build Nupkg and Test Against Built & Installed Module

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,8 @@
 # Grab nuget bits, set build variables, start build.
 Get-PackageProvider -Name NuGet -ForceBootstrap > $null
 
+Import-Module "$env:PROJECTROOT/PSKoans"
+
 Set-BuildEnvironment
 
 $Lines = '-' * 70
@@ -31,8 +33,5 @@ catch {
 # Build external help files from Platyps MD files
 New-ExternalHelp -Path "$env:PROJECTROOT/docs/" -OutputPath "$env:PROJECTROOT/PSKoans/en-us"
 
-$BuiltModuleFolder = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/Module/"
-Write-Host "##vso[task.setvariable variable=BuiltModuleFolder]$BuiltModuleFolder"
-
-New-Item -Path $BuiltModuleFolder -ItemType Directory
-Copy-Item -Path "$env:PROJECTROOT/PSKoans" -Destination $BuiltModuleFolder -Recurse -PassThru
+Copy-Item -Path "$env:PROJECTROOT/PSKoans" -Destination $env:BUILTMODULEPATH -Recurse -PassThru |
+    Where-Object { -not $_.PSIsContainer }

--- a/Build/Register-FileSystemRepository.ps1
+++ b/Build/Register-FileSystemRepository.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $Path,
+
+    [Parameter(Mandatory)]
+    [string]
+    $Name
+)
+
+$RepositoryFolder = if (-not (Test-Path $Path)) {
+    New-Item -ItemType Directory -Path $Path -Force
+}
+else {
+    Get-Item -Path $Path
+}
+
+$Params = @{
+    Name                 = $Name
+    SourceLocation       = $RepositoryFolder.FullName
+    ScriptSourceLocation = $RepositoryFolder.FullName
+    InstallationPolicy   = 'Trusted'
+}
+Register-PSRepository @Params

--- a/Deploy/Publish.ps1
+++ b/Deploy/Publish.ps1
@@ -13,14 +13,6 @@ param(
 $env:NugetApiKey = $Key
 
 if ($OutputDirectory) {
-    $Params = @{
-        Name                 = 'FileSystem'
-        SourceLocation       = "$PSScriptRoot/FileSystem"
-        ScriptSourceLocation = "$PSScriptRoot/FileSystem"
-        InstallationPolicy   = 'Trusted'
-    }
-    Register-PSRepository @Params
-
     Import-Module "$PSScriptRoot/PSKoans"
     $Module = Get-Module -Name PSKoans
     $Dependencies = @(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,62 +14,50 @@ trigger:
 pr:
 - master
 
+variables:
+  NupkgArtifactName: 'PSKoans.nupkg'
+
 stages:
-- stage: LinuxTests
-  displayName: 'Linux'
+- stage: UploadChangelog
+  displayName: 'Upload Changelog'
   dependsOn: []
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
 
   jobs:
-  - job: Linux
-    displayName: 'Pester Tests'
+  - job: GenerateChangelog
+    displayName: "Generate Changelog"
 
     pool:
       vmImage: ubuntu-latest
 
-    steps:
-    - template: templates/environment-setup.yml
-    - template: templates/test-steps.yml
+    variables:
+      FilePath: '$(System.DefaultWorkingDirectory)/Changelog.md'
 
-- stage: WindowsTests
-  displayName: 'Windows'
+    steps:
+    - task: PowerShell@2
+      displayName: 'Create Changelog'
+      inputs:
+        targetType: 'filepath'
+        filePath: ./Build/New-Changelog.ps1
+        arguments: -Path '$(FilePath)' -ApiKey $(GithubApiKey) -Verbose
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Changelog'
+      inputs:
+        path: '$(FilePath)'
+        artifact: Changelog
+
+- stage: Build
+  displayName: 'Build PSKoans'
   dependsOn: []
 
-  jobs:
-  - job: Windows
-    displayName: 'Pester Tests'
-
-    pool:
-      vmImage: windows-latest
-
-    steps:
-    - template: templates/environment-setup.yml
-    - template: templates/test-steps.yml
-
-- stage: MacOSTests
-  displayName: 'MacOS'
-  dependsOn: []
+  variables:
+    FileSystemDeploymentPath: '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
+    BuiltModulePath: '$(System.DefaultWorkingDirectory)/Deploy/PSKoans'
 
   jobs:
-  - job: MacOS
-    displayName: 'Pester Tests'
-
-    pool:
-      vmImage: macOS-latest
-
-    steps:
-    - template: templates/environment-setup.yml
-    - template: templates/test-steps.yml
-
-- stage: PublishModule
-  displayName: 'Create Module'
-  dependsOn:
-    - LinuxTests
-    - WindowsTests
-    - MacOSTests
-
-  jobs:
-  - job: BuildModule
-    displayName: "Build PSKoans"
+  - job: BuildNupkg
+    displayName: 'Module Nupkg'
 
     pool:
       vmImage: ubuntu-latest
@@ -78,7 +66,7 @@ stages:
     - template: templates/environment-setup.yml
 
     - task: PowerShell@2
-      displayName: 'Initialize Environment'
+      displayName: 'Stage PSKoans Module'
 
       inputs:
         targetType: 'filePath'
@@ -91,34 +79,19 @@ stages:
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Built Module Artifact'
       inputs:
-        path: '$(BuiltModuleFolder)/PSKoans'
+        path: '$(BuiltModulePath)'
         artifact: PSKoans
 
-  - job: PublishFiles
-    dependsOn: BuildModule
-    displayName: "Publish Artifacts"
-
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      builtModulePath: '$(System.DefaultWorkingDirectory)/Deploy/PSKoans'
-      fileSystemDeploymentPath: '$(System.DefaultWorkingDirectory)/Deploy/FileSystem'
-
-    steps:
-    - template: templates/environment-setup.yml
-
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download Built Module Artifact'
-      inputs:
-        artifact: PSKoans
-        path: $(builtModulePath)
+    - template: ./templates/register-local-repo.yml
+      parameters:
+        repositoryPath: '$(FileSystemDeploymentPath)'
 
     - task: PowerShell@2
       displayName: 'Create Module Nupkg'
       inputs:
         targetType: 'filePath'
         filePath: ./Deploy/Publish.ps1
-        arguments: -Key 'filesystem' -Path '$(fileSystemDeploymentPath)' -OutputDirectory '$(fileSystemDeploymentPath)'
+        arguments: -Key 'filesystem' -Path '$(FileSystemDeploymentPath)' -OutputDirectory '$(FileSystemDeploymentPath)'
 
         errorActionPreference: 'stop'
         failOnStderr: true
@@ -128,18 +101,107 @@ stages:
       displayName: 'Publish Nupkg Artifact'
       inputs:
         path: '$(NupkgPath)'
-        artifact: PSKoans.nupkg
+        artifact: '$(NupkgArtifactName)'
 
-  - job: PublishToGallery
-    displayName: 'Publish PSKoans to PSGallery'
-    dependsOn: PublishFiles
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+- stage: LinuxTests
+  displayName: 'Linux'
+  dependsOn:
+  - Build
+
+  variables:
+    PackageDownloadPath: '$(System.DefaultWorkingDirectory)/Module'
+    PSRepositoryName: 'FileSystem'
+
+  jobs:
+  - job: Linux
+    displayName: 'Pester Tests'
 
     pool:
       vmImage: ubuntu-latest
+
+    steps:
+    - template: templates/environment-setup.yml
+
+    - template: ./templates/install-built-module.yml
+      parameters:
+        repositoryPath: '$(PackageDownloadPath)'
+        repositoryName: '$(PSRepositoryName)'
+        artifactName: '$(NupkgArtifactName)'
+
+    - template: templates/test-steps.yml
+
+- stage: WindowsTests
+  displayName: 'Windows'
+  dependsOn:
+  - Build
+
+  variables:
+    PackageDownloadPath: '$(System.DefaultWorkingDirectory)/Module'
+    PSRepositoryName: 'FileSystem'
+
+  jobs:
+  - job: Windows
+    displayName: 'Pester Tests'
+
+    pool:
+      vmImage: windows-latest
+
+    steps:
+    - template: templates/environment-setup.yml
+
+    - template: ./templates/install-built-module.yml
+      parameters:
+        repositoryPath: '$(PackageDownloadPath)'
+        repositoryName: '$(PSRepositoryName)'
+        artifactName: '$(NupkgArtifactName)'
+
+    - template: templates/test-steps.yml
+
+- stage: MacOSTests
+  displayName: 'MacOS'
+  dependsOn:
+  - Build
+
+  variables:
+    PackageDownloadPath: '$(System.DefaultWorkingDirectory)/Module'
+    PSRepositoryName: 'FileSystem'
+
+  jobs:
+  - job: MacOS
+    displayName: 'Pester Tests'
+
+    pool:
+      vmImage: macOS-latest
+
+    steps:
+    - template: templates/environment-setup.yml
+
+    - template: ./templates/install-built-module.yml
+      parameters:
+        repositoryPath: '$(PackageDownloadPath)'
+        repositoryName: '$(PSRepositoryName)'
+        artifactName: '$(NupkgArtifactName)'
+
+    - template: templates/test-steps.yml
+
+- stage: PublishModule
+  displayName: 'Publish Module'
+  dependsOn:
+    - LinuxTests
+    - WindowsTests
+    - MacOSTests
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+
+  jobs:
+  - job: PublishToGallery
+    displayName: 'PowerShell Gallery'
+
+    pool:
+      vmImage: ubuntu-latest
+
     variables:
-      builtModulePath: '$(System.DefaultWorkingDirectory)/Deploy/PSKoans'
-      galleryDeploymentPath: '$(System.DefaultWorkingDirectory)/Deploy/PSGallery'
+      BuiltModulePath: '$(System.DefaultWorkingDirectory)/Deploy/PSKoans'
+      GalleryDeploymentPath: '$(System.DefaultWorkingDirectory)/Deploy/PSGallery'
 
     steps:
     - template: templates/environment-setup.yml
@@ -148,43 +210,16 @@ stages:
       displayName: 'Download Built Module Artifact'
       inputs:
         artifact: PSKoans
-        path: $(builtModulePath)
+        path: $(BuiltModulePath)
 
     - task: PowerShell@2
       displayName: 'Publish Module to PSGallery'
 
       inputs:
         targetType: 'filePath'
-        arguments: -Key $(PSApiKey) -Path '$(galleryDeploymentPath)'
+        arguments: -Key $(PSApiKey) -Path '$(GalleryDeploymentPath)'
         filePath: ./Deploy/Publish.ps1
 
         errorActionPreference: 'stop'
         failOnStderr: true
         pwsh: true
-
-- stage: CreateChangelog
-  displayName: 'Upload Changelog'
-  dependsOn: []
-  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/master')
-
-  jobs:
-  - job: GenerateChangelog
-    displayName: "Generate Changelog"
-    pool:
-      vmImage: ubuntu-latest
-    variables:
-      filePath: '$(System.DefaultWorkingDirectory)/Changelog.md'
-
-    steps:
-    - task: PowerShell@2
-      displayName: 'Create Changelog'
-      inputs:
-        targetType: 'filepath'
-        filePath: ./Build/New-Changelog.ps1
-        arguments: -Path '$(filePath)' -ApiKey $(GithubApiKey) -Verbose
-
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Changelog'
-      inputs:
-        path: '$(filePath)'
-        artifact: Changelog

--- a/templates/install-built-module.yml
+++ b/templates/install-built-module.yml
@@ -1,0 +1,36 @@
+parameters:
+- name: repositoryPath
+  type: string
+  default: '$(System.DefaultWorkingDirectory)'
+- name: repositoryName
+  type: string
+  default: 'FileSystem'
+- name: artifactName
+  type: string
+  default: 'PSKoans.nupkg'
+
+steps:
+- template: ./register-local-repo.yml
+  parameters:
+    repositoryPath: ${{ parameters.repositoryPath }}
+    repositoryName: ${{ parameters.repositoryName }}
+
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Built Module Artifact'
+  inputs:
+    artifact: ${{ parameters.artifactName }}
+    path: ${{ parameters.repositoryPath }}
+
+- task: PowerShell@2
+  displayName: 'Install PSKoans from Nupkg'
+  inputs:
+    targetType: 'inline'
+    script: |
+      Register-PackageSource -Name PSGallery -ProviderName NuGet -Location https://www.powershellgallery.com/api/v2 -Force
+      Save-Package -Name Pester -ProviderName NuGet -Path ${{ parameters.repositoryPath }} -Force -Source PSGallery |
+          Select-Object -Property Name, Version, Status, Source
+      Install-Module PSKoans -Repository ${{ parameters.repositoryName }} -Force -Scope CurrentUser
+
+    errorActionPreference: 'stop'
+    failOnStderr: true
+    pwsh: true

--- a/templates/register-local-repo.yml
+++ b/templates/register-local-repo.yml
@@ -1,0 +1,19 @@
+parameters:
+- name: repositoryPath
+  type: string
+  default: '$(System.DefaultWorkingDirectory)'
+- name: repositoryName
+  type: string
+  default: 'FileSystem'
+
+steps:
+- task: PowerShell@2
+  displayName: 'Register FileSystem Repository'
+  inputs:
+    targetType: 'filePath'
+    filePath: ./Build/Register-FileSystemRepository.ps1
+    arguments: -Path '${{ parameters.repositoryPath }}' -Name '${{ parameters.repositoryName }}'
+
+    errorActionPreference: 'stop'
+    failOnStderr: true
+    pwsh: true


### PR DESCRIPTION
# PR Summary

Refactor the Azure configuration to build the module nupkg before running tests. This allows us to run tests against a properly built & installed version of the module, to ensure nothing in the build process breaks functionality.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
