### PR TITLE
Add Move-PSKoanLibrary Function

### DIFF
--- a/PSKoans/PSKoans.psd1
+++ b/PSKoans/PSKoans.psd1
@@ -76,17 +76,24 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport     = @(
         'Get-Blank'
+        'Get-Karma'
+        'Get-PSKoan'
+        'Get-PSKoanLocation'
+        'Get-PSKoanSetting'
+
+        'Set-PSKoanLocation'
+        'Set-PSKoanSetting'
+
+        'Move-PSKoanLibrary'
+
+        'Reset-PSKoan'
+
+        'Register-Advice'
+
         'Show-Advice'
         'Show-Karma'
-        'Register-Advice'
-        'Get-PSKoanLocation'
-        'Set-PSKoanLocation'
-        'Get-PSKoanSetting'
-        'Set-PSKoanSetting'
-        'Reset-PSKoan'
+
         'Update-PSKoan'
-        'Get-PSKoan'
-        'Get-Karma'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/PSKoans/Private/New-PSKoanErrorRecord.ps1
+++ b/PSKoans/Private/New-PSKoanErrorRecord.ps1
@@ -85,6 +85,10 @@ function New-PSKoanErrorRecord {
             $Exception = $ExceptionType::new( $ExceptionMessage )
         }
 
+        if ($ErrorId -notmatch '^PSKoans\.') {
+            $ErrorId = "PSKoans.$($ErrorId)"
+        }
+
         [ErrorRecord]::new(
             $Exception,
             $ErrorId,

--- a/PSKoans/Public/Move-PSKoanLibrary.ps1
+++ b/PSKoans/Public/Move-PSKoanLibrary.ps1
@@ -1,0 +1,21 @@
+function Move-PSKoanLibrary {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium',
+        HelpUri = 'https://github.com/vexx32/PSKoans/tree/master/docs/Move-PSKoanLibrary.md')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [Alias('PSPath', 'Folder')]
+        [string]
+        $Path
+    )
+    process {
+        if ($PSCmdlet.ShouldProcess($Path, 'Move existing koan files here')) {
+            $OriginalPath = Get-PSKoanLocation
+
+            Write-Verbose "Moving library files from '$OriginalPath' to '$Path'"
+            Move-Item -Path $OriginalPath -Destination $Path -ErrorAction Stop
+
+            Set-PSKoanLocation -Path $Path
+        }
+    }
+}

--- a/PSKoans/Public/Move-PSKoanLibrary.ps1
+++ b/PSKoans/Public/Move-PSKoanLibrary.ps1
@@ -3,8 +3,8 @@ function Move-PSKoanLibrary {
         HelpUri = 'https://github.com/vexx32/PSKoans/tree/master/docs/Move-PSKoanLibrary.md')]
     [OutputType([void])]
     param(
-        [Parameter(Mandatory, Position = 0)]
-        [Alias('PSPath', 'Folder')]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
+        [Alias('PSPath', 'Folder', 'Destination', 'TargetPath')]
         [string]
         $Path
     )
@@ -13,9 +13,11 @@ function Move-PSKoanLibrary {
             $OriginalPath = Get-PSKoanLocation
 
             Write-Verbose "Moving library files from '$OriginalPath' to '$Path'"
-            Move-Item -Path $OriginalPath -Destination $Path -ErrorAction Stop
+            Move-Item -Path $OriginalPath -Destination $Path -ErrorAction Stop -PassThru
 
-            Set-PSKoanLocation -Path $Path
+            if ($?) {
+                Set-PSKoanLocation -Path $Path
+            }
         }
     }
 }

--- a/PSKoans/Public/Set-PSKoanLocation.ps1
+++ b/PSKoans/Public/Set-PSKoanLocation.ps1
@@ -5,7 +5,6 @@ function Set-PSKoanLocation {
     param(
         [Parameter(Mandatory, Position = 0)]
         [Alias('PSPath', 'Folder')]
-        [FolderTransformAttribute()]
         [string]
         $Path,
 
@@ -14,13 +13,24 @@ function Set-PSKoanLocation {
         $PassThru
     )
     begin {
-        $resolvedPath = $PSCmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath($aPath)
+        $resolvedPath = $PSCmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 
         if ($resolvedPath.Count -gt 1 -or [WildcardPattern]::ContainsWildcardCharacters($resolvedPath)) {
             $ErrorDetails = @{
                 ExceptionType    = [System.Management.Automation.PSArgumentException]
                 ExceptionMessage = 'Wildcarded paths are not supported.'
                 ErrorId          = 'InvalidPath'
+                ErrorCategory    = 'InvalidArgument'
+                TargetObject     = $Path
+            }
+            $PSCmdlet.ThrowTerminatingError((New-PSKoanErrorRecord @ErrorDetails))
+        }
+
+        if (Test-Path $resolvedPath -PathType Leaf) {
+            $ErrorDetails = @{
+                ExceptionType    = [System.Management.Automation.PSArgumentException]
+                ExceptionMessage = 'You cannot use a file path as the location for your PSKoans library.'
+                ErrorId          = 'InvalidPathType'
                 ErrorCategory    = 'InvalidArgument'
                 TargetObject     = $Path
             }

--- a/Tests/Functions/Private/New-PSKoanErrorRecord.Tests.ps1
+++ b/Tests/Functions/Private/New-PSKoanErrorRecord.Tests.ps1
@@ -3,6 +3,7 @@
 Describe 'New-PSKoanErrorRecord' {
 
     Context 'With Exception Object' {
+
         BeforeAll {
             $Output, $Parameters = InModuleScope 'PSKoans' {
                 $Params = @{
@@ -20,16 +21,29 @@ Describe 'New-PSKoanErrorRecord' {
             $Output | Should -BeOfType System.Management.Automation.ErrorRecord
         }
 
-        It 'creates output with properties matching the parameters supplied' {
+        It 'emits the same type of exception' {
             $Output.Exception | Should -BeOfType $Parameters.Exception.GetType().FullName
+        }
+
+        It 'includes the input exception message' {
             $Output.Exception.Message | Should -BeExactly $Parameters.Exception.Message
+        }
+
+        It 'emits the correct error ID with "PSKoans" prefix' {
             $Output.FullyQualifiedErrorId | Should -BeExactly "PSKoans.$($Parameters.ErrorId)"
+        }
+
+        It 'assigns the requested error category' {
             $Output.CategoryInfo.Category | Should -Be $Parameters.ErrorCategory
-            $Output.TargetObject | Should -BeNullOrEmpty
+        }
+
+        It 'assigns the target object' {
+            $Output.TargetObject | Should -Be $Params.TargetObject
         }
     }
 
     Context 'With TypeName and Message' {
+
         BeforeAll {
             $Output, $Parameters = InModuleScope 'PSKoans' {
                 $Params = @{
@@ -48,12 +62,24 @@ Describe 'New-PSKoanErrorRecord' {
             $Output | Should -BeOfType System.Management.Automation.ErrorRecord
         }
 
-        It 'creates output with properties matching the parameters supplied' {
+        It 'creates the correct type of exception' {
             $Output.Exception | Should -BeOfType $Parameters.ExceptionType
+        }
+
+        It 'applies the requested exception message' {
             $Output.Exception.Message | Should -BeExactly $Parameters.ExceptionMessage
+        }
+
+        It 'emits the correct error ID with "PSKoans" prefix' {
             $Output.FullyQualifiedErrorId | Should -BeExactly "PSKoans.$($Parameters.ErrorId)"
+        }
+
+        It 'assigns the requested error category' {
             $Output.CategoryInfo.Category | Should -Be $Parameters.ErrorCategory
-            $Output.TargetObject | Should -BeNullOrEmpty
+        }
+
+        It 'assigns the target object' {
+            $Output.TargetObject | Should -Be $Params.TargetObject
         }
     }
 }

--- a/Tests/Functions/Private/New-PSKoanErrorRecord.Tests.ps1
+++ b/Tests/Functions/Private/New-PSKoanErrorRecord.Tests.ps1
@@ -21,11 +21,11 @@ Describe 'New-PSKoanErrorRecord' {
         }
 
         It 'creates output with properties matching the parameters supplied' {
-            $Output.Exception             | Should -BeOfType $Parameters.Exception.GetType().FullName
-            $Output.Exception.Message     | Should -BeExactly $Parameters.Exception.Message
-            $Output.FullyQualifiedErrorId | Should -BeExactly $Parameters.ErrorId
+            $Output.Exception | Should -BeOfType $Parameters.Exception.GetType().FullName
+            $Output.Exception.Message | Should -BeExactly $Parameters.Exception.Message
+            $Output.FullyQualifiedErrorId | Should -BeExactly "PSKoans.$($Parameters.ErrorId)"
             $Output.CategoryInfo.Category | Should -Be $Parameters.ErrorCategory
-            $Output.TargetObject	      | Should -BeNullOrEmpty
+            $Output.TargetObject | Should -BeNullOrEmpty
         }
     }
 
@@ -49,11 +49,11 @@ Describe 'New-PSKoanErrorRecord' {
         }
 
         It 'creates output with properties matching the parameters supplied' {
-            $Output.Exception             | Should -BeOfType $Parameters.ExceptionType
-            $Output.Exception.Message     | Should -BeExactly $Parameters.ExceptionMessage
-            $Output.FullyQualifiedErrorId | Should -BeExactly $Parameters.ErrorId
+            $Output.Exception | Should -BeOfType $Parameters.ExceptionType
+            $Output.Exception.Message | Should -BeExactly $Parameters.ExceptionMessage
+            $Output.FullyQualifiedErrorId | Should -BeExactly "PSKoans.$($Parameters.ErrorId)"
             $Output.CategoryInfo.Category | Should -Be $Parameters.ErrorCategory
-            $Output.TargetObject	      | Should -BeNullOrEmpty
+            $Output.TargetObject | Should -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Functions/Public/Move-PSKoanLibrary.Tests.ps1
+++ b/Tests/Functions/Public/Move-PSKoanLibrary.Tests.ps1
@@ -1,0 +1,82 @@
+#Requires -Modules PSKoans
+
+Describe 'Move-PSKoanLibrary' {
+
+    Context 'Unit Tests with Mocks' {
+
+        BeforeAll {
+            $OriginalPath = New-Item -Path 'TestDrive:/PSKoans' -ItemType Directory |
+                Select-Object -ExpandProperty FullName
+            $TestPath = New-Item -ItemType Directory -Path 'TestDrive:/TestPath' | Join-Path -ChildPath 'Koans'
+
+            Mock Get-PSKoanLocation { $OriginalPath }.GetNewClosure() -ModuleName PSKoans
+            Mock Set-PSKoanLocation -ParameterFilter { $Path -eq $TestPath } -ModuleName PSKoans
+            Mock Move-Item -ParameterFilter { $Path -eq $OriginalPath } -MockWith { $Destination }  -ModuleName PSKoans
+        }
+
+        It 'should output the new location' {
+            Move-PSKoanLibrary -Path $TestPath | Should -BeExactly $TestPath
+        }
+
+        It 'should call Get-PSKoanLocation' {
+            Assert-MockCalled Get-PSKoanLocation -ModuleName PSKoans
+        }
+
+        It 'should call Move-Item' {
+            Assert-MockCalled Move-Item -ModuleName PSKoans
+        }
+
+        It 'should call Set-PSKoanLocation' {
+            Assert-MockCalled Set-PSKoanLocation -ModuleName PSKoans
+        }
+    }
+
+    Context 'Integration Tests' {
+
+        BeforeAll {
+            $OldLocation = Get-PSKoanLocation
+
+            Set-PSKoanLocation -Path 'TestDrive:/PSKoans'
+            Update-PSKoan -Confirm:$false
+
+            $OriginalFileHashes = Get-PSKoanLocation |
+                Get-ChildItem -Recurse -File |
+                Get-FileHash |
+                ForEach-Object {
+                    @{
+                        File = ($_.Path -split [regex]::Escape([IO.Path]::DirectorySeparatorChar))[-2, -1] -join ':'
+                        Hash = $_.Hash
+                    }
+                }
+
+            $NewLocation = 'TestDrive:/NewLocation/PSKoans'
+            New-Item -Path ($NewLocation | Split-Path -Parent) -ItemType Directory
+        }
+
+        AfterAll {
+            Set-PSKoanLocation $OldLocation
+        }
+
+        It 'should move the folder to the new location' {
+            Move-PSKoanLibrary -Path $NewLocation
+            Test-Path $NewLocation -PathType Container | Should -BeTrue
+        }
+
+        It 'should update the KoanLocation' {
+            Get-PSKoanLocation | Should -BeExactly (Get-Item -Path $NewLocation).FullName
+        }
+
+        It 'should copy <File> to the new location' -TestCases $OriginalFileHashes {
+            param($File, $Hash)
+
+            $FileName = ($File -split ':')[-1]
+
+            $NewHash = Get-ChildItem -Path $NewLocation -Recurse -File -Filter "*$FileName*" |
+                Get-FileHash |
+                Select-Object -ExpandProperty Hash
+
+            $NewHash | Should -BeExactly $Hash
+        }
+    }
+
+}

--- a/docs/Move-PSKoanLibrary.md
+++ b/docs/Move-PSKoanLibrary.md
@@ -1,0 +1,103 @@
+---
+external help file: PSKoans-help.xml
+Module Name: PSKoans
+online version: https://github.com/vexx32/PSKoans/tree/master/docs/Move-PSKoanLibrary.md
+schema: 2.0.0
+---
+
+# Move-PSKoanLibrary
+
+## SYNOPSIS
+
+Move your entire current PSKoans library folder to another location and update your KoanLocation setting to reflect the new location.
+
+## SYNTAX
+
+```powershell
+Move-PSKoanLibrary [-Path] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Move-PSKoanLibrary` takes your current PSKoans library location and moves the folder to the specified destination.
+Then, it updates the current KoanLocation setting to point to the new location.
+
+## EXAMPLES
+
+### Example
+
+```powershell
+PS C:\> Move-PSKoanLibrary -Path C:\Users\Joe\OneDrive
+```
+
+Moves Joe's koan library into his OneDrive directory.
+
+## PARAMETERS
+
+### -Path
+
+The path to the new library location.
+This path can be relative to the current session location, but cannot contain wildcards.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: PSPath, Folder
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+## RELATED LINKS
+
+[https://github.com/vexx32/PSKoans/tree/master/docs/Move-PSKoanLibrary.md](https://github.com/vexx32/PSKoans/tree/master/docs/Move-PSKoanLibrary.md)

--- a/docs/Move-PSKoanLibrary.md
+++ b/docs/Move-PSKoanLibrary.md
@@ -47,7 +47,7 @@ Aliases: PSPath, Folder
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
# PR Summary

Adds a `Move-PSKoanLibrary` public function which moves the entire PSKoans library folder and sets the new location in the module configuration.

## Context

Resolves #325

## Changes

- Added `Move-PSKoanLibrary` command
- Added tests for new command

Tangential:

- Fixed a couple minor issues with `Set-PSKoanLocation` that I found in the process.
- Added an automatic `PSKoans.` prefix for ErrorIds emitted from `New-PSKoanErrorRecord`

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
