### PR TITLE
AboutTypeOperators - fixes $null output returning a collection

### DIFF
--- a/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutTypeOperators.Koans.ps1
@@ -59,7 +59,7 @@ Describe 'Type Operators' {
 
             $Casting | Should -Throw -ErrorId '____'
             $Conversion | Should -Not -Throw
-            __ | Should -Be $Conversion.Invoke()
+            __ | Should -Be $Conversion.InvokeReturnAsIs()
         }
     }
 }


### PR DESCRIPTION
Invoke() on a scriptblock returns an (empty) collection,
but only a signle $null value is expected.
Using InvokeReturnAsIs() fixes this issue.


## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
