### PR TITLE
(#372) AboutEnumerations: Use Version-Appropriate TryParse() Method

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutEnumerations.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutEnumerations.Koans.ps1
@@ -307,7 +307,24 @@ Describe 'About Enumerations' {
             $enumType = [DayOfWeek]
             $parseResult = [DayOfWeek]::Sunday
 
-            $result = [Enum]::TryParse($enumType, $valueToParse, [Ref]$parseResult)
+            $result = if ($PSVersionTable.PSVersion.Major -gt 5) {
+                <#
+                    .NET Core's TryParse() method (available in PS v6+) can take
+                    an explicit type argument. When available, this is a more
+                    robust method to work with.
+                #>
+                [Enum]::TryParse($enumType, $valueToParse, [ref]$parseResult)
+            }
+            else {
+                <#
+                    This method still works, but it relies on the [ref] variable
+                    already containing a valid enum value from the target type.
+                    This is because the method is actually a generic method,
+                    and PS has no way to specify a target type, instead being
+                    forced to infer the target type from the result variable.
+                #>
+                [Enum]::TryParse($valueToParse, [ref]$parseResult)
+            }
 
             $result | Should -BeTrue
             $parseResult | Should -Not -Be 'Sunday'


### PR DESCRIPTION
# PR Summary

The overload used is only available in .NET Core; add a branch checking the version to select the appropriate method.

## Context

Resolves #372 

## Changes

- Add a version check so we can pick the appropriate method.
- Add some commentary to explain the choice of method.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
