### PR TITLE
(#376) [Show-Karma] Enable -Contemplate with -Topic

### DIFF
--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -7,6 +7,7 @@ function Show-Karma {
         [Parameter(ParameterSetName = 'ListKoans')]
         [Parameter(ParameterSetName = 'ModuleOnly')]
         [Parameter(ParameterSetName = 'IncludeModule')]
+        [Parameter(ParameterSetName = 'OpenFile')]
         [Parameter(ParameterSetName = 'Default')]
         [Alias('Koan', 'File')]
         [SupportsWildcards()]
@@ -87,7 +88,7 @@ function Show-Karma {
         }
         'OpenFile' {
             # If there is no cached data, we need to call Get-Karma to populate it
-            if (-not $script:CurrentTopic) {
+            if (-not $script:CurrentTopic -or ($Topic -and $script:CurrentTopic.Name -ne $Topic)) {
                 try {
                     # We can discard this; the results we need are saved in $script:CurrentTopic
                     $null = Get-Karma @GetParams

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -88,7 +88,7 @@ function Show-Karma {
         }
         'OpenFile' {
             # If there is no cached data, we need to call Get-Karma to populate it
-            if (-not $script:CurrentTopic -or ($Topic -and $script:CurrentTopic.Name -ne $Topic)) {
+            if (-not $script:CurrentTopic -or ($Topic -and $script:CurrentTopic.Name -notlike $Topic)) {
                 try {
                     # We can discard this; the results we need are saved in $script:CurrentTopic
                     $null = Get-Karma @GetParams

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -281,6 +281,18 @@ Describe 'Show-Karma' {
                 $script:CurrentTopic | Should -BeNullOrEmpty
             }
 
+            It 'opens the specified -Topic in the selected editor' {
+                Set-PSKoanSetting -Name Editor -Value 'code'
+                $Result = Show-Karma -Contemplate -Topic TestTopic
+
+                $Result.Arguments[1] | Should -MatchExactly ([regex]::Escape($TestFile.FullName))
+
+                Assert-MockCalled Get-Command -Times 1
+                Assert-MockCalled Start-Process -Times 1
+
+                $script:CurrentTopic | Should -BeNullOrEmpty
+            }
+
             It 'invokes the set editor with unknown editor chosen' {
                 Set-PSKoanSetting -Name Editor -Value 'vim'
 

--- a/docs/Show-Karma.md
+++ b/docs/Show-Karma.md
@@ -17,6 +17,11 @@ Reflect on your progress and check your answers.
 Show-Karma [-Topic <String[]>] [-ClearScreen] [-Detailed] [<CommonParameters>]
 ```
 
+### OpenFile
+```
+Show-Karma [-Topic <String[]>] [-Contemplate] [-ClearScreen] [<CommonParameters>]
+```
+
 ### IncludeModule
 ```
 Show-Karma [-Topic <String[]>] -IncludeModule <String[]> [-ClearScreen] [-Detailed] [<CommonParameters>]
@@ -30,11 +35,6 @@ Show-Karma [-Topic <String[]>] -Module <String[]> [-ClearScreen] [-Detailed] [<C
 ### ListKoans
 ```
 Show-Karma [-Topic <String[]>] [-Module <String[]>] [-List] [-ClearScreen] [<CommonParameters>]
-```
-
-### OpenFile
-```
-Show-Karma [-Contemplate] [-ClearScreen] [<CommonParameters>]
 ```
 
 ### OpenFolder
@@ -63,6 +63,13 @@ Opens the current koan file in the editor specified by the `Editor` setting.
 Use [`Set-PSKoanSetting`](./Set-PSKoanSetting.md) to change the editor used.
 
 If a known editor (`code`, `code-insiders`, or `atom`) is used, PSKoans will pass along line information as well.
+
+### EXAMPLE 3
+```powershell
+Show-Karma -Contemplate -Topic AboutComparison
+```
+
+Opens the specified `AboutComparison` topic file in the preferred editor.
 
 ## PARAMETERS
 
@@ -195,10 +202,11 @@ Accept wildcard characters: False
 ### -Topic
 Execute koans only from the selected Topic(s).
 Wildcard patterns are permitted.
+When provided along with `-Contemplate`, the targeted topic will be respected.
 
 ```yaml
 Type: String[]
-Parameter Sets: Default, IncludeModule, ModuleOnly, ListKoans
+Parameter Sets: Default, OpenFile, IncludeModule, ModuleOnly, ListKoans
 Aliases: Koan, File
 
 Required: False

--- a/docs/Show-Karma.md
+++ b/docs/Show-Karma.md
@@ -19,27 +19,27 @@ Show-Karma [-Topic <String[]>] [-ClearScreen] [-Detailed] [<CommonParameters>]
 
 ### OpenFile
 ```
-Show-Karma [-Topic <String[]>] [-Contemplate] [-ClearScreen] [<CommonParameters>]
+Show-Karma -Contemplate [-Topic <String[]>] [-ClearScreen] [<CommonParameters>]
 ```
 
 ### IncludeModule
 ```
-Show-Karma [-Topic <String[]>] -IncludeModule <String[]> [-ClearScreen] [-Detailed] [<CommonParameters>]
+Show-Karma -IncludeModule <String[]> [-Topic <String[]>] [-ClearScreen] [-Detailed] [<CommonParameters>]
 ```
 
 ### ModuleOnly
 ```
-Show-Karma [-Topic <String[]>] -Module <String[]> [-ClearScreen] [-Detailed] [<CommonParameters>]
+Show-Karma -Module <String[]> [-Topic <String[]>] [-ClearScreen] [-Detailed] [<CommonParameters>]
 ```
 
 ### ListKoans
 ```
-Show-Karma [-Topic <String[]>] [-Module <String[]>] [-List] [-ClearScreen] [<CommonParameters>]
+Show-Karma -List [-Topic <String[]>] [-Module <String[]>] [-ClearScreen] [<CommonParameters>]
 ```
 
 ### OpenFolder
 ```
-Show-Karma [-Library] [-ClearScreen] [<CommonParameters>]
+Show-Karma -Library [-ClearScreen] [<CommonParameters>]
 ```
 
 ## DESCRIPTION


### PR DESCRIPTION
# PR Summary

Enables use of `-Contemplate` with `-Topic` for `Show-Karma`

## Context

Resolves #376 

## Changes

- Added `-Topic` as an optional parameter to the `OpenFile` parameter set.
- Amended branching logic to ensure that cached topic information is only used if it matches the selected topic, if a topic is selected.
- Added test to ensure the correct topic path is passed when a topic is selected.
- Amended documentation to clarify that this parameter combination is supported.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
