### PR TITLE
fixes wrong variable used for property count

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
@@ -157,7 +157,7 @@ Describe 'System.Text.StringBuilder' {
             Get-Member |
             Where-Object MemberType -eq 'Property'
 
-            $ExpectedCount = $Properties |
+            $ExpectedPropertyCount = $Properties |
             Measure-Object |
             Select-Object -ExpandProperty Count
 


### PR DESCRIPTION
# PR Summary

This PR fixes a mismatched variable.
$ExpectedCount was assigned a value but $ExpectedPropertyCount was queried for the value.

Fixes ##367

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
