### PR TITLE
fixes problematic assertions in AboutPSObjects

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutPSObjects.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutPSObjects.Koans.ps1
@@ -36,7 +36,7 @@ Describe 'PSObject' {
             'Methods'
             '____'
             '____'
-        ) | Should -Be $PSObjectProperties
+        ) | Sort-Object | Should -Be $PSObjectProperties
     }
 
     It "details the base object's properties and methods" {
@@ -49,8 +49,9 @@ Describe 'PSObject' {
             'LongLength'
             '____'
             'SyncRoot'
-        )
-        $PropertyNames | Should -Be $Object.PSObject.Properties.Name | Sort-Object
+        ) | Sort-Object
+        $ExpectedProperties = $Object.PSObject.Properties.Name | Sort-Object
+        $PropertyNames | Should -Be $ExpectedProperties
 
         $Methods = $Object.PSObject.Methods
         __ | Should -Be $Methods.ForEach{$_}.Count
@@ -73,7 +74,7 @@ Describe 'PSObject' {
             '____',
             '____',
             '____'
-        ) | Should -Be $PropertyNames
+        ) | Sort-Object | Should -Be $PropertyNames
         __ | Should -Be $Empty.IsReadOnly
     }
 
@@ -109,7 +110,7 @@ Describe 'PSObject' {
             Sort-Object
 
         # There may be varying property types depending on your PowerShell version
-        @( '____', '____', '____' ) | Should -Be $PropertyTypes
+        @( '____', '____', '____' ) | Sort-Object | Should -Be $PropertyTypes
     }
 
     It "can find derivative properties" {
@@ -127,6 +128,6 @@ Describe 'PSObject' {
             ForEach-Object -MemberName Name |
             Sort-Object
 
-        @( '____', '____', '____', '____') | Should -Be $PropertyTypes
+        @( '____', '____', '____', '____') | Sort-Object | Should -Be $PropertyTypes
     }
 }


### PR DESCRIPTION
fixes problematic assertions in AboutPSObjects

# PR Summary
missing sorting in AboutPSObject.Koans.ps1 might deem a test a failure
even if the answers were correct, but in the wrong order

Fixes #366 

## Context
The intention here is to sort the property names from $Object.PSObject.Properties to ensure the property names are always in the same order

## Changes
At all spots were the reference value was sorted, a Sort-Object was added for the difference value.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
