### PR TITLE
Add missing $array variable to It block in AboutArrays Koan

### DIFF
--- a/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutArrays.Koans.ps1
@@ -194,6 +194,7 @@ Describe 'Arrays' {
     }
 
     It 'can reverse an array' {
+        $Array = 1, 2, 3, 4, 5, 6, 7
         $LastIndex = __
         $Array[-1..$LastIndex] | Should -Be @(7, 6, 5, 4, 3, 2, 1)
     }


### PR DESCRIPTION
There is a missing $array variable assignment in one of the array koan tests. The test will always fail unless you provide a value for $array.

<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

Noticed while practicing the Koans.

<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

Updates AboutArrays.Koans.ps1

<!--
List any and all changes here, in bullet point form.
-->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
