### PR TITLE
line 130 error in pester test

### DIFF
--- a/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
@@ -127,6 +127,6 @@ Describe "Get Member" {
 
         $cmdlet1, $cmdlet2, $cmdlet3 |
             Get-Unique |
-            Should -BeTrue -Because "three unique cmdlets should be supplied"
+            Should -HaveCount 3 -Because "three unique cmdlets should be supplied"
     }
 }


### PR DESCRIPTION
# PR Summary

<!--
A string in the pipeline is always "$true"
Therefore: 

line 130: Should -BeTrue ==> Should -HaveCount 3

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

<!--
List any and all changes here, in bullet point form.
-->

## Checklist

- [ ] Pull Request has a meaningful title.
- [ ] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
