### PR TITLE
Pin Pester dependency to v4

### DIFF
--- a/PSKoans/PSKoans.psd1
+++ b/PSKoans/PSKoans.psd1
@@ -53,8 +53,8 @@
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules       = @(
         @{
-            ModuleName    = 'Pester'
-            ModuleVersion = '4.3.1'
+            ModuleName      = 'Pester'
+            RequiredVersion = '4.10.1'
         }
     )
 

--- a/templates/environment-setup.yml
+++ b/templates/environment-setup.yml
@@ -17,9 +17,11 @@ steps:
 
       $Params.Name = 'Pester'
       $Params.SkipPublisherCheck = $true
+      $Params.MaximumVersion = '4.99.99'
       $Params | Out-String | Write-Host
       Install-Module @Params
       $Params.Remove('SkipPublisherCheck')
+      $Params.Remove('MaximumVersion')
 
       $Params.Name = 'EZOut'
       $Params.AllowClobber = $true

--- a/templates/install-built-module.yml
+++ b/templates/install-built-module.yml
@@ -26,9 +26,17 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
+      $pesterParams = @{
+          Name           = 'Pester'
+          MaximumVersion = '4.99.99'
+          ProviderName   = 'NuGet'
+          Path           = '${{ parameters.repositoryPath }}'
+          Force          = $true
+          Source         = 'PSGallery'
+      }
+
       Register-PackageSource -Name PSGallery -ProviderName NuGet -Location https://www.powershellgallery.com/api/v2 -Force
-      Save-Package -Name Pester -ProviderName NuGet -Path ${{ parameters.repositoryPath }} -Force -Source PSGallery |
-          Select-Object -Property Name, Version, Status, Source
+      Save-Package @pesterParams | Select-Object -Property Name, Version, Status, Source
       Install-Module PSKoans -Repository ${{ parameters.repositoryName }} -Force -Scope CurrentUser
 
     errorActionPreference: 'stop'


### PR DESCRIPTION
# PR Summary

Pins the Pester version required for the module to `4.10.1` since `RequiredModules` doesn't appear to support a `MaximumVersion`, and also pins the build pipeline to maximum version of `4.99.99` for Pester.

## Context

Currently users can install Pester v5 and PSKoans will be trying to utilise that version on import; this will cause things to break.

This should force PowerShellGet to retrieve the right version from the gallery when installing the new PSKoans version and avoid that breakage until I can update this module to work with v5 of Pester.

## Changes

- Set `RequiredVersion` in the manifest for Pester
- Set `-MaximumVersion` in the CI pipeline for Pester

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
