### PR TITLE
Updating typo in PSHome variable

### DIFF
--- a/PSKoans/Koans/Introduction/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutStrings.Koans.ps1
@@ -65,7 +65,7 @@ Describe 'Strings' {
 
                 This could be the result of a typing mistake.
             #>
-            $String = "PowerShell's home folder is: $SPHome"
+            $String = "PowerShell's home folder is: $PSHome"
             '____' | Should -Be $String
         }
 


### PR DESCRIPTION
# PR Summary

Updates a typo from SPHome to PSHome in Strings Koan
<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

Goal is to add better clarity for the user
<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

- Fixed typo for PSHome in AboutString
<!--

List any and all changes here, in bullet point form.
-->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
