### PR TITLE
Add -NoNewWindow to Start-Process in Show-Karma -Meditat

### DIFF
--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -117,7 +117,7 @@ function Show-Karma {
             }
 
             if ($Editor -and (Get-Command -Name $Editor -ErrorAction SilentlyContinue)) {
-                Start-Process -FilePath $Editor -ArgumentList $Arguments
+                Start-Process -FilePath $Editor -ArgumentList $Arguments -NoNewWindow
             }
             else {
                 Invoke-Item -Path $FilePath

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -229,7 +229,7 @@ Describe 'Show-Karma' {
                 Mock Get-Command { $true } -ParameterFilter { $Name -ne "missing_editor" }
                 Mock Get-Command { $false } -ParameterFilter { $Name -eq "missing_editor" }
                 Mock Start-Process {
-                    @{ Editor = $FilePath; Arguments = $ArgumentList }
+                    @{ Editor = $FilePath; Arguments = $ArgumentList; NoNewWindow = $NoNewWindow }
                 }
                 Mock Get-Karma -ModuleName 'PSKoans' {
                     $script:CurrentTopic = @{
@@ -267,6 +267,7 @@ Describe 'Show-Karma' {
                 $Result.Arguments[0] | Should -BeExactly '--goto'
                 $Result.Arguments[1] | Should -MatchExactly '"[^"]+":\d+'
                 $Result.Arguments[2] | Should -BeExactly '--reuse-window'
+                $Result.NoNewWindow | Should -BeTrue
 
                 # Resolve-Path doesn't like embedded quotes
                 $Path = ($Result.Arguments[1] -split '(?<="):')[0] -replace '"'


### PR DESCRIPTION
# PR Summary

Start-Process by default opens a new console. We generally do not want this to be the case for Show-Karma -Meditate.
<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

Fixes #395
<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

- Add `-NoNewWindow` to `Start-Process` call in `Show-Karma`

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
