### PR TITLE
Update to Pester v5

### DIFF
--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -1,43 +1,29 @@
 $Lines = '-' * 70
-$PSVersion = $PSVersionTable.PSVersion
-
-Write-Host $Lines
-Write-Host "STATUS: Testing with PowerShell v$($PSVersionTable.PSVersion)"
-Write-Host $Lines
-
-# Import the module and add temporary entry to PSModulePath for build/test purposes
 
 Import-Module 'PSKoans'
 
-$Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"
-$TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
-$CodeCoverageFile = "PS${PSVersion}_${TimeStamp}_PSKoans.CodeCoverage.xml"
+$PesterVersion = (Get-Module -Name Pester).Version
+$PSVersion = $PSVersionTable.PSVersion
 
-$ModuleFolders = @(
-    Get-Item -Path "$env:PROJECTROOT/PSKoans"
-    Get-ChildItem -Path "$env:PROJECTROOT/PSKoans" -Directory -Recurse |
-        Where-Object { 'Koans' -notin $_.Parent.Name, $_.Parent.Parent.Name }
-).FullName -join ';'
+Write-Host $Lines
+Write-Host "TEST: PowerShell Version: $PSVersion"
+Write-Host "TEST: Pester Version: $PesterVersion"
+Write-Host $Lines
 
-# Tell Azure where the test results & code coverage files will be
-Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
-Write-Host "##vso[task.setvariable variable=CodeCoverageFile]$CodeCoverageFile"
-Write-Host "##vso[task.setvariable variable=SourceFolders]$ModuleFolders"
-
-# Gather test results. Store them in a variable and file
-$PesterParams = @{
-    Path                   = "$env:PROJECTROOT/Tests"
-    PassThru               = $true
-    OutputFormat           = 'NUnitXml'
-    OutputFile             = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
-    Show                   = "Header", "Failed", "Summary"
-    CodeCoverage           = (Get-ChildItem -Recurse -Path "$env:PROJECTROOT/PSKoans" -Filter '*.ps*1' -Exclude '*.Koans.ps1').FullName
-    CodeCoverageOutputFile = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$CodeCoverageFile"
+try {
+    # Try/Finally required since -CI will exit with exit code on failure.
+    Invoke-Pester -Path "$env:PROJECTROOT/Tests" -CI -Output Normal
 }
-$TestResults = Invoke-Pester @PesterParams
+finally {
+    $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"
+    $TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
+    $CodeCoverageFile = "PS${PSVersion}_${TimeStamp}_PSKoans.CodeCoverage.xml"
 
-# If tests failed, write errors and exit
-if ($TestResults.FailedCount -gt 0) {
-    Write-Error "Failed $($TestResults.FailedCount) tests; build failed!"
-    exit $TestResults.FailedCount
+    # Tell Azure what the test results & code coverage file names will be
+    Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
+    Write-Host "##vso[task.setvariable variable=CodeCoverageFile]$CodeCoverageFile"
+
+    # Move files generated from Invoke-Pester to expected location
+    Move-Item -Path './testResults.xml' -Destination "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"
+    Move-Item -Path './coverage.xml' -Destination "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$CodeCoverageFile"
 }

--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -12,7 +12,7 @@ Write-Host $Lines
 
 try {
     # Try/Finally required since -CI will exit with exit code on failure.
-    Invoke-Pester -Path "$env:PROJECTROOT/Tests" -CI -Output Normal
+    Invoke-Pester -Path "$env:PROJECTROOT" -CI -Output Normal
 }
 finally {
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"

--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -19,9 +19,16 @@ finally {
     $TestFile = "PS${PSVersion}_${TimeStamp}_PSKoans.TestResults.xml"
     $CodeCoverageFile = "PS${PSVersion}_${TimeStamp}_PSKoans.CodeCoverage.xml"
 
+    $ModuleFolders = @(
+        Get-Item -Path "$env:PROJECTROOT/PSKoans"
+        Get-ChildItem -Path "$env:PROJECTROOT/PSKoans" -Directory -Recurse |
+            Where-Object FullName -NotMatch '[\\/]Tests[\\/]|[\\/]PSKoans[\\/]Koans[\\/]'
+    ).FullName -join ';'
+
     # Tell Azure what the test results & code coverage file names will be
     Write-Host "##vso[task.setvariable variable=TestResults]$TestFile"
     Write-Host "##vso[task.setvariable variable=CodeCoverageFile]$CodeCoverageFile"
+    Write-Host "##vso[task.setvariable variable=SourceFolders]$ModuleFolders"
 
     # Move files generated from Invoke-Pester to expected location
     Move-Item -Path './testResults.xml' -Destination "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/$TestFile"

--- a/KoanIndex.md
+++ b/KoanIndex.md
@@ -60,13 +60,18 @@ When adding or updating koan topics, please keep this file up to date.
 
 ### ActiveDirectory
 
-| Folder                  | Topic                                                          | Position |
-| ----------------------- | :------------------------------------------------------------- | :------: |
-| Introduction            | [AboutFiltering][ActiveDirectory\AboutFiltering]               |   101    |
+| Folder       | Topic                                            | Position |
+| ------------ | :----------------------------------------------- | :------: |
+| Introduction | [AboutFiltering][ActiveDirectory\AboutFiltering] |   101    |
 
 ### Dbatools
 
-> TBD
+| Folder   | Topic                                                     | Position |
+| -------- | :-------------------------------------------------------- | :------: |
+| dbatools | [AboutDbaDatabase][dbatools\AboutDbaDatabase]             |   1001   |
+| dbatools | [AboutQueryingDatabases][dbatools\AboutQueryingDatabases] |   1002   |
+| dbatools | [AboutNewDatabases][dbatools\AboutNewDatabases]           |   1003   |
+| dbatools | [AboutBackupDatabases][dbatools\AboutBackupDatabases]     |   1004   |
 
 <!-- Links for default koan topics -->
 
@@ -120,3 +125,8 @@ When adding or updating koan topics, please keep this file up to date.
 <!-- Add links for koans from other modules below this line -->
 
 [ActiveDirectory\AboutFiltering]: PSKoans/Koans/Modules/ActiveDirectory/Introduction/AboutFiltering.Koans.ps1
+
+[dbatools\AboutDbaDatabase]: PSKoans/Koans/Modules/dbatools/AboutDbaDatabase.Koans.ps1
+[dbatools\AboutQueryingDatabases]: PSKoans/Koans/Modules/dbatools/AboutQueryingDatabases.Koans.ps1
+[dbatools\AboutNewDatabases]: PSKoans/Koans/Modules/dbatools/AboutNewDatabases.Koans.ps1
+[dbatools\AboutBackupDatabases]: PSKoans/Koans/Modules/dbatools/AboutBackupDatabases.Koans.ps1

--- a/PSKoans.ezformat.ps1
+++ b/PSKoans.ezformat.ps1
@@ -1,38 +1,37 @@
-#Requires -Modules EZOut
-# Install-Module EZOut
-# or https://github.com/StartAutomating/EZOut
-
-$VerbosePreference = 'Continue'
-
-$ModuleName = $MyInvocation.MyCommand.Name -replace '\.ezformat\.ps1', ''
-$ModuleFolder = Get-Item -Path "$PSScriptRoot/PSKoans" | Select-Object -ExpandProperty FullName
-
-Write-Verbose "Building format file for '$ModuleName' in '$ModuleFolder'"
-
+#requires -Module EZOut
+#  Install-Module EZOut or https://github.com/StartAutomating/EZOut
+$myFile = $MyInvocation.MyCommand.ScriptBlock.File
+$myModuleName = 'PSKoans'
+$myRoot = "$PSScriptRoot"
+Push-Location $myRoot
 $formatting = @(
+    # Add your own Write-FormatView here,
+    # or put them in a Formatting or Views directory
     foreach ($potentialDirectory in 'formatting', 'views') {
-        $path = Join-Path $PSScriptRoot -ChildPath $potentialDirectory
-        if (Test-Path $path) {
-            Get-ChildItem -Path $path | ForEach-Object {
-                Write-Verbose "Processing file '$($_.FullName)'"
-                Import-FormatView -FilePath $_.FullName
-            }
-        }
+        Join-Path $myRoot -ChildPath $potentialDirectory |
+            Get-ChildItem -ea ignore |
+            Import-FormatView -FilePath { $_.Fullname }
     }
 )
 
+$destinationRoot = "$PSScriptRoot/PSKoans"
+
 if ($formatting) {
-    $formatFilePath = Join-Path $ModuleFolder -ChildPath "$ModuleName.format.ps1xml"
-    Write-Verbose "Writing format file to '$formatFilePath'"
-    $formatting | Out-FormatData -Module $ModuleName | Set-Content $formatFilePath -Encoding UTF8
+    $myFormatFile = Join-Path $destinationRoot "$myModuleName.format.ps1xml"
+    $formatting | Out-FormatData -Module $MyModuleName | Set-Content $myFormatFile -Encoding UTF8
 }
 
 $types = @(
     # Add your own Write-TypeView statements here
+    # or declare them in the 'Types' directory
+    Join-Path $myRoot Types |
+        Get-Item -ea ignore |
+        Import-TypeView
+
 )
 
 if ($types) {
-    $TypesFile = Join-Path $PSScriptRoot "$ModuleName.types.ps1xml"
-    Write-Verbose "Writing types file to '$TypesFile'"
-    $types | Out-TypeData | Set-Content $TypesFile -Encoding UTF8
+    $myTypesFile = Join-Path $destinationRoot "$myModuleName.types.ps1xml"
+    $types | Out-TypeData | Set-Content $myTypesFile -Encoding UTF8
 }
+Pop-Location

--- a/PSKoans/Koans/Cmdlets 2/AboutCsvCmdlets.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 2/AboutCsvCmdlets.Koans.ps1
@@ -19,7 +19,7 @@ param()
     handled directly by PowerShell's CSV cmdlets without some extra work.
 #>
 
-Describe '*-Csv Cmdlets' {
+Describe 'CSV Cmdlets' {
 
     Context 'Export-Csv' {
         <#
@@ -81,7 +81,21 @@ Describe '*-Csv Cmdlets' {
         }
 
         It 'allows you to specify the delimiter' {
+            $Delimiter = '_'
+            $Path = 'TestDrive:/DelimitedData.csv'
 
+            $Text = @(
+                '"Number","Square"'
+                '"__"?"__"'
+                '"__"?"__"'
+                '"__"?"__"'
+                '"__"?"__"'
+                '"__"?"__"'
+            )
+
+            $Objects | Export-Csv -Path $Path -Delimiter $Delimiter
+            $FileContents = Get-Content -Path $Path
+            $Text | Should -BeExactly $FileContents
         }
     }
 
@@ -207,6 +221,7 @@ Describe '*-Csv Cmdlets' {
     }
 
     Context 'ConvertFrom-Csv' {
+
         BeforeAll {
             $CsvString = @"
 "Number","Square"

--- a/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 2/AboutOutCmdlets.Koans.ps1
@@ -77,7 +77,6 @@ Context 'Out-* Cmdlets' {
             partially because in older versions of PowerShell it has a different default
             encoding than those cmdlets, frequently confusing users.
         #>
-
         It 'stores data in files' {
             $Path = 'TestDrive:\File.txt'
 

--- a/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutSplatting.Koans.ps1
@@ -15,6 +15,7 @@ param()
     'splatted' into the command by specifying the variable name with an @ symbol: @Variable
 #>
 Describe 'Splatting' {
+
     BeforeAll {
         $PSKoansFolder = Get-PSKoanLocation
     }
@@ -74,8 +75,8 @@ Describe 'Splatting' {
             }
 
             Get-ChildItem @Parameters |
-            Select-Object -First 1 |
-            Should -BeOfType 'System.IO.FileInfo'
+                Select-Object -First 1 |
+                Should -BeOfType 'System.IO.FileInfo'
         }
 
         It 'can be built from automatic hashtables' {

--- a/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutStringBuilder.Koans.ps1
@@ -96,6 +96,7 @@ Describe 'System.Text.StringBuilder' {
     }
 
     Context 'Constructing the Final String Object' {
+
         BeforeAll {
             $SB = [System.Text.StringBuilder]::new("Hello!")
             $SB.Append("BYE!")
@@ -115,9 +116,11 @@ Describe 'System.Text.StringBuilder' {
     }
 
     Context 'Other StringBuilder Methods' {
+
         BeforeAll {
             $StringBuilder = [System.Text.StringBuilder]::new("TEXT")
         }
+
         It 'can be cleared' {
             $StringBuilder.Clear()
             $StringBuilder.Length | Should -Be 0
@@ -143,6 +146,7 @@ Describe 'System.Text.StringBuilder' {
     }
 
     Context 'StringBuilder Properties' {
+
         BeforeAll {
             $StringBuilder = [System.Text.StringBuilder]::new()
             $StringBuilder.AppendLine('When you look into the void,')
@@ -154,12 +158,12 @@ Describe 'System.Text.StringBuilder' {
             $PropertyName = '____'
 
             $Properties = $StringBuilder |
-            Get-Member |
-            Where-Object MemberType -eq 'Property'
+                Get-Member |
+                Where-Object MemberType -EQ 'Property'
 
             $ExpectedPropertyCount = $Properties |
-            Measure-Object |
-            Select-Object -ExpandProperty Count
+                Measure-Object |
+                Select-Object -ExpandProperty Count
 
             $PropertyCount | Should -Be $ExpectedPropertyCount
             $PropertyName | Should -BeIn $Properties.Name

--- a/PSKoans/Koans/Foundations/AboutAssignmentAndArithmetic.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutAssignmentAndArithmetic.Koans.ps1
@@ -98,6 +98,7 @@ Describe 'Arithmetic Operators' {
             __ | Should -Be $Array
         }
     }
+
     Context 'Subtraction' {
 
         It 'works similarly to addition' {
@@ -148,9 +149,10 @@ Describe 'Arithmetic Operators' {
     }
 
     Context 'Modulus' {
-
-        # Modulus is a bit of an odd one, but common enough in programming. It performs a
-        # division, and then returns the integer value of the remainder.
+        <#
+                Modulus is a bit of an odd one, but common enough in programming. It performs a
+            division, and then returns the integer value of the remainder.
+        #>
         It 'is usually used with integers' {
             $Remainder = 15 % 7
             __ | Should -Be $Remainder

--- a/PSKoans/Koans/Introduction/AboutBinary.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutBinary.Koans.ps1
@@ -43,108 +43,155 @@ param()
     one, and 1 + 2 is equal to 3.
 #>
 
-Describe "Binary conversion" {
+Describe 'Binary Conversions' {
 
-    It "Bit conversion" {
-        # What would 0 be if converted to be boolean?
-        # Replace __ with either $true or $false
-        $____ -as [int] | Should -Be 0
+    Context 'Boolean Conversions' {
 
-        # What would 1 be if converted to be boolean?
-        # Replace __ with either $true or $false
-        $____ -as [int] | Should -Be 1
+        It 'converts $false to an integer' {
+            $ExpectedResult = $false -as [int]
+
+            # What would $false be if converted to a number?
+            __ | Should -Be $ExpectedResult
+        }
+
+        It 'converts $true to an integer' {
+            $ExpectedResult = $true -as [int]
+
+            # What would $true be if converted to a number?
+            __ | Should -Be $ExpectedResult
+        }
     }
 
-    It "Binary to integer conversion" {
-        # Replace __ with the decimal value of 1111
-        # E.G. __ becomes 1234
-        $Binary = "1111"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 1000
-        $Binary = "1000"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 0010
-        $Binary = "0010"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 1001
-        $Binary = "1001"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 11111111
-        $Binary = "11111111"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 10101010
-        $Binary = "10101010"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 11001100
-        $Binary = "11001100"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-        # Replace __ with the decimal value of 11110001
-        $Binary = "11110001"
-        $Value = __
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
-
-
-    }
-
-    It "Integer to Binary conversion" {
+    Context "Binary to Integer Conversion" {
         <#
-            Convert the following integers into their binary representation
+            Replace the blanks below with the decimal value of the binary
+            numbers in each case. For example, the binary sequence "10" is
+            represented by the number 2 in the standard decimal system.
         #>
+        It 'converts 1111 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
 
-        # Replace __ with the binary value of 7
-        # E.G. "__" becomes "0100"
-        $Binary = "____"
-        $Value = 7
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+            # Replace the __ with the decimal value of 1111
+            $Binary = "1111"
+            __ | Should -Be $ExpectedValue
+        }
 
-        # Replace __ with the binary value of 12
-        $Binary = "____"
-        $Value = 12
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+        It 'converts 1000 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
 
-        # Replace __ with the binary value of 2
-        $Binary = "____"
-        $Value = 2
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+            # Replace __ with the decimal value of 1000
+            $Binary = "1000"
+            __ | Should -Be $ExpectedValue
+        }
 
-        # Replace __ with the binary value of 14
-        $Binary = "____"
-        $Value = 14
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+        It 'converts 0010 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
 
-        # Replace __ with the binary value of 103
-        # E.G. "__" becomes "01001110"
-        $Binary = "____"
-        $Value = 103
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+            # Replace __ with the decimal value of 0010
+            $Binary = "0010"
+            __ | Should -Be $ExpectedValue
+        }
 
-        # Replace __ with the binary value of 250
-        $Binary = "____"
-        $Value = 250
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+        It 'converts 1001 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
 
-        # Replace __ with the binary value of 74
-        $Binary = "____"
-        $Value = 74
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+            # Replace __ with the decimal value of 1001
+            $Binary = "1001"
+            __ | Should -Be $ExpectedValue
+        }
 
-        # Replace __ with the binary value of 32
-        $Binary = "____"
-        $Value = 32
-        $Value | Should -Be ([Convert]::ToInt32($Binary, 2))
+        It 'converts 11111111 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
+
+            # Replace __ with the decimal value of 11111111
+            $Binary = "11111111"
+            __ | Should -Be $ExpectedValue
+        }
+
+        It 'converts 10101010 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
+
+            # Replace __ with the decimal value of 10101010
+            $Binary = "10101010"
+            __ | Should -Be $ExpectedValue
+        }
+
+        It 'converts 11001100 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
+
+            # Replace __ with the decimal value of 11001100
+            $Binary = "11001100"
+            __ | Should -Be $ExpectedValue
+        }
+
+        It 'converts 11110001 to an integer' {
+            $ExpectedValue = [Convert]::ToInt32($Binary, 2)
+
+            # Replace __ with the decimal value of 11110001
+            $Binary = "111g10001"
+            __ | Should -Be $ExpectedValue
+        }
+    }
+
+    Context "Integer to Binary Conversion" {
+        <#
+            Convert the following integers into their binary representation.
+            For example, 2 is represented in binary with the digits "10".
+        #>
+        It 'converts the integer 7 to binary' {
+            # Replace ____ with the binary value of 7
+            $Value = 7
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be $Binary
+        }
+
+        It 'converts the integer 12 to binary' {
+            # Replace __ with the binary value of 12
+            $Value = 12
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 2 to binary' {
+            # Replace __ with the binary value of 2
+            $Value = 2
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 14 to binary' {
+            # Replace __ with the binary value of 14
+            $Value = 14
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 103 to binary' {
+            # Replace __ with the binary value of 103
+            $Value = 103
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 250 to binary' {
+            # Replace __ with the binary value of 250
+            $Value = 250
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 74 to binary' {
+            # Replace __ with the binary value of 74
+            $Value = 74
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
+
+        It 'converts the integer 32 to binary' {
+            # Replace __ with the binary value of 32
+            $Value = 32
+            $Binary = [Convert]::ToString($Value, 2)
+            '____' | Should -Be ([Convert]::ToInt32($Binary, 2))
+        }
     }
 }

--- a/PSKoans/Koans/Introduction/AboutBooleans.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutBooleans.Koans.ps1
@@ -8,7 +8,7 @@ param()
     allow us to represent a logical, binary, state. Effectively, they represent
     the state of a single bit of data. For example:
 
-        | "Can I stop this service?"
+        "Can I stop this service?"
 
     The answer is yes or no, True or False.
 
@@ -27,30 +27,42 @@ param()
 #>
 
 Describe "Booleans" {
+    <#
+        Fill in the blanks below with either $true or $false, indicating the
+        result you expect from the noted expressions.
 
-    # Using only booleans, either $true or $false, fill in the blanks below.
+        We'll cover comparison operators in more detail later on, but here's a
+        summary of the operators used here:
 
-    It '( 1 -gt 2 ) is either true or false' {
+            -gt => "is greater than"
+            -eq => "is equal to"
+            -lt => "is less than"
+
+        As an example, the expression 7 -gt 5 asserts "7 is greater than 5".
+        This is a true statement, so the final value of the expression is $true.
+    #>
+
+    It 'evaluates ( 1 -gt 2 ) as a boolean expression' {
         $____ | Should -Be ( 1 -gt 2 ) -Because '1 is not greater than 2'
     }
 
-    It '( 1 -lt 2 ) is either true or false' {
+    It 'evaluates ( 1 -lt 2 ) as a boolean expression' {
         $____ | Should -Be ( 1 -lt 2 ) -Because '1 is less than 2'
     }
 
-    It '( 10 -lt 20 ) is either true or false' {
+    It 'evaluates ( 10 -lt 20 ) as a boolean expression' {
         $____ | Should -Be ( 10 -lt 20 ) -Because '10 is less than 20'
     }
 
-    It '( 10 -gt 20 ) is either true or false' {
+    It 'evaluates ( 10 -gt 20 ) as a boolean expression' {
         $____ | Should -Be ( 10 -gt 20 ) -Because 'The lesser is not greater'
     }
 
-    It '( 3 -eq 3 ) is either true or false' {
+    It 'evaluates ( 3 -eq 3 ) as a boolean expression' {
         $____ | Should -Be ( 3 -eq 3 ) -Because 'A mirror reflects true'
     }
 
-    It '( 100 -lt 1 ) is either true or false' {
+    It 'evaluates ( 100 -lt 1 ) as a boolean expression' {
         $____ | Should -Be ( 100 -lt 1 ) -Because '100 is not less than 1'
     }
 }

--- a/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
@@ -38,95 +38,129 @@ param()
 #>
 
 Describe "Get Member" {
-<#
-    Use Get-Member to identify properties or methods of some common objects!
 
-    Make sure you use a different cmdlet each time, we'll be checking :)
-#>
+    Context 'Exploring Object Properties' {
+        <#
+            Let's look at some object properties!
 
-    It 'allows us to explore properties on an object' {
+            Using any three cmdlets you like (make sure you use three different
+            cmdlets!), use Get-Member in your console to peek at the properties
+            on the object.
 
-        # Get some properties!
+            Let's see an example; by sending the output from Get-Process into
+            Get-Member we can inspect the objects Get-Process outputs. You can
+            run the below command in your console:
 
-        <# EXAMPLE
+                Get-Process | Get-Member -MemberType Property
 
-        $Cmdlet1 = 'Get-Process'
-        $PropertyName = 'Threads'
-        $Reason = $BecauseString -f $PropertyName, $cmdlet1
-        & (Get-Command -Name $Cmdlet1) |
-            Get-Member -MemberType Property -Name $PropertyName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            From the output of the above command, we will see that one of the
+            properties is named "Threads", so using that cmdlet name and that
+            property name will satisfy one of the tests below.
 
+            The others are up to you! Get-* cmdlets will be most helpful here;
+            if you're not sure which to try, you can use the following command
+            to list Get-* cmdlets you can try out:
+
+                Get-Command -Verb Get
         #>
-        $BecauseString = "property '{0}' should be present in output from {1}"
+        BeforeAll {
+            $Cmdlets = [System.Collections.Generic.HashSet[string]]::new()
+            $PropertyString = "property '{0}' should be present in output from {1}"
+            $UniqueString = 'unique cmdlets should be used for each test'
+        }
 
-        $Cmdlet1 = '____'
-        $PropertyName = '____'
+        It 'lists one of the properties of the first unique command' {
+            $CmdletName = '____'
+            $PropertyName = '____'
 
-        $Reason = $BecauseString -f $PropertyName, $cmdlet1
-        & (Get-Command -Name $Cmdlet1) |
-            Get-Member -MemberType Property -Name $PropertyName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            $Reason = $PropertyString -f $PropertyName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $PropertyName |
+                Should -Not -BeNullOrEmpty -Because $Reason
 
-        $Cmdlet2 = '____'
-        $PropertyName = '____'
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
 
-        $Reason = $BecauseString -f $PropertyName, $cmdlet2
-        & (Get-Command -Name $Cmdlet2) |
-            Get-Member -MemberType Property -Name $PropertyName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+        It 'lists one of the properties of the second unique command' {
+            $CmdletName = '____'
+            $PropertyName = '____'
 
-        $Cmdlet3 = '____'
-        $PropertyName = '____'
+            $Reason = $PropertyString -f $PropertyName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $PropertyName |
+                Should -Not -BeNullOrEmpty -Because $Reason
 
-        $Reason = $BecauseString -f $PropertyName, $cmdlet3
-        & (Get-Command -Name $Cmdlet3) |
-            Get-Member -MemberType Property -Name $PropertyName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
 
-        $cmdlet1, $cmdlet2, $cmdlet3 |
-            Get-Unique |
-            Should -HaveCount 3 -Because "three unique cmdlets should be supplied"
+        It 'lists one of the properties of the third unique command' {
+            $CmdletName = '____'
+            $PropertyName = '____'
+
+            $Reason = $PropertyString -f $PropertyName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $PropertyName |
+                Should -Not -BeNullOrEmpty -Because $Reason
+
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
     }
 
-    It 'allows us to explore methods on an object' {
+    Context 'Exploring Object Methods' {
+        <#
+            Similar to above, you can inspect the methods available from an
+            object that a cmdlet outputs, by changing the -MemberType value
+            you provide to Get-Member:
 
-        # Get some methods!
+                Get-Process | Get-Member -MemberType Method
 
-        <# EXAMPLE
+            If you don't provide a -MemberType option and value, it will simply
+            list all the members, regardless of the kind of members they are.
 
-        $Cmdlet1 = 'Get-Process'
-        $MethodName = 'Close'
-        $Reason = $BecauseString -f $MethodName, $cmdlet1
-        & (Get-Command -Name $Cmdlet1) |
-            Get-Member -MemberType Property -Name $MethodName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            You can reuse the same set of cmdlets from above here if you wish,
+            but you will need to check to see if there are methods available on
+            the objects they output!
         #>
-        $BecauseString = "method '{0}' should be present in output from {1}"
+        BeforeAll {
+            $Cmdlets = [System.Collections.Generic.HashSet[string]]::new()
+            $MethodString = "property '{0}' should be present in output from {1}"
+            $UniqueString = 'unique cmdlets should be used for each test'
+        }
 
-        $Cmdlet1 = '____'
-        $MethodName = '____'
-        $Reason = $BecauseString -f $MethodName, $cmdlet1
-        & (Get-Command -Name $Cmdlet1) |
-            Get-Member -MemberType Method -Name $MethodName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+        It 'lists one of the methods of the first unique command' {
+            $CmdletName = '____'
+            $MethodName = '____'
 
-        $Cmdlet2 = '____'
-        $MethodName = '____'
-        $Reason = $BecauseString -f $MethodName, $cmdlet2
-        & (Get-Command -Name $Cmdlet2) |
-            Get-Member -MemberType Method -Name $MethodName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            $Reason = $MethodString -f $MethodName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $MethodName |
+                Should -Not -BeNullOrEmpty -Because $Reason
 
-        $Cmdlet3 = '____'
-        $MethodName = '____'
-        $Reason = $BecauseString -f $MethodName, $cmdlet3
-        & (Get-Command -Name $Cmdlet3) |
-            Get-Member -MemberType Method -Name $MethodName |
-            Should -Not -BeNullOrEmpty -Because $Reason
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
 
-        $cmdlet1, $cmdlet2, $cmdlet3 |
-            Get-Unique |
-            Should -HaveCount 3 -Because "three unique cmdlets should be supplied"
+        It 'lists one of the methods of the second unique command' {
+            $CmdletName = '____'
+            $MethodName = '____'
+
+            $Reason = $MethodString -f $MethodName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $MethodName |
+                Should -Not -BeNullOrEmpty -Because $Reason
+
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
+
+        It 'lists one of the methods of the third unique command' {
+            $CmdletName = '____'
+            $MethodName = '____'
+
+            $Reason = $MethodString -f $MethodName, $CmdletName
+            & (Get-Command -Name $CmdletName) |
+                Get-Member -MemberType Property -Name $MethodName |
+                Should -Not -BeNullOrEmpty -Because $Reason
+
+            $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
+        }
     }
 }

--- a/PSKoans/Koans/Introduction/AboutNumbers.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutNumbers.Koans.ps1
@@ -26,17 +26,25 @@ Describe 'Basic Number Types' {
 
     Context 'Double' {
 
-        It 'can result from an operation involving multiple types of numbers' {
+        BeforeAll {
+            $Int = 10
+            $Double = 10.0
+        }
+
+        It 'has a specific object type for integers' {
+            'System.____' | Should -Be $Int.GetType().Fullname
+        }
+
+        It 'has a specific object type for doubles' {
+            'System.____' | Should -Be $Double.GetType().Fullname
+        }
+
+        It 'can result from mathematical operations with other number types' {
             <#
                 When doing arithmetic on different types of numbers, PowerShell
                 will automatically convert the less precise or more narrow type
                 to the other kind.
             #>
-            $Int = 10
-            $Double = 10.0
-
-            'System.____' | Should -Be $Int.GetType().Fullname
-            'System.____' | Should -Be $Double.GetType().Fullname
 
             $Result = $Int * $Double
 

--- a/PSKoans/Koans/Katas/ProcessingStrings.Koans.ps1
+++ b/PSKoans/Koans/Katas/ProcessingStrings.Koans.ps1
@@ -26,6 +26,7 @@ param()
     -Joel
 #>
 Describe "The Stock Challenge" {
+
     BeforeAll {
         $StockData = @(
             "Date,Open,High,Low,Close,Volume,Adj Close"

--- a/PSKoans/PSKoans.psd1
+++ b/PSKoans/PSKoans.psd1
@@ -54,7 +54,7 @@
     RequiredModules       = @(
         @{
             ModuleName      = 'Pester'
-            RequiredVersion = '4.10.1'
+            MinimumVersion  = '5.0.2'
         }
     )
 
@@ -68,7 +68,7 @@
     # TypesToProcess = @()
 
     # Format files (.ps1xml) to be loaded when importing this module
-    FormatsToProcess      = @('PSKoans.format.ps1xml')
+    FormatsToProcess      = @( 'PSKoans.format.ps1xml' )
 
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     # NestedModules = @()
@@ -86,9 +86,9 @@
 
         'Move-PSKoanLibrary'
 
-        'Reset-PSKoan'
-
         'Register-Advice'
+
+        'Reset-PSKoan'
 
         'Show-Advice'
         'Show-Karma'
@@ -106,13 +106,17 @@
     AliasesToExport       = @(
         'Invoke-PSKoans'
         'Test-Koans'
-        'Get-Enlightenment'
-        'Measure-Karma'
+
         '__'
         '____'
         'FILL_ME_IN'
+
         'Clear-Path'
+
         'Get-Advice'
+
+        'Get-Enlightenment'
+        'Measure-Karma'
     )
 
     # DSC resources to export from this module
@@ -172,5 +176,4 @@
 
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''
-
 }

--- a/PSKoans/PSKoans.psd1
+++ b/PSKoans/PSKoans.psd1
@@ -54,7 +54,7 @@
     RequiredModules       = @(
         @{
             ModuleName      = 'Pester'
-            MinimumVersion  = '5.0.2'
+            ModuleVersion   = '5.0.2'
         }
     )
 

--- a/PSKoans/PSKoans.psm1
+++ b/PSKoans/PSKoans.psm1
@@ -21,6 +21,7 @@ $script:DefaultSettings = @{
 }
 
 [hashtable] $script:CurrentTopic = $null
+[runspace] $script:KoanRunspace = $null
 
 #region SupportingClasses
 

--- a/PSKoans/Private/Assert-UnblockedFile.ps1
+++ b/PSKoans/Private/Assert-UnblockedFile.ps1
@@ -43,7 +43,7 @@ function Assert-UnblockedFile {
             }
         }
 
-        if (Get-Content -Path $FileInfo.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) {
+        if (Get-Content -Path $FileInfo.FullName -Stream Zone.Identifier -ErrorAction Ignore) {
             $ErrorDetails = @{
                 ExceptionType    = 'System.IO.FileLoadException'
                 ExceptionMessage = 'Could not read the koan file "{0}". The file is blocked and may have been copied from an Internet location. Use the Unblock-File to remove the block on the file.' -f $FileInfo.FullName

--- a/PSKoans/Private/Measure-Koan.ps1
+++ b/PSKoans/Private/Measure-Koan.ps1
@@ -1,7 +1,4 @@
-﻿using namespace System.Management.Automation
-using namespace System.Management.Automation.Language
-
-function Measure-Koan {
+﻿function Measure-Koan {
     <#
     .SYNOPSIS
         Counts the number of koans in the provided ExternalScriptInfo objects.
@@ -10,24 +7,15 @@ function Measure-Koan {
         files to find all of the 'It' blocks in order to count the total number of Pester
         tests present in the file.
 
-        When provided with a piped list of ExternalScriptInfo objects, sums the entire
+        When provided with a piped list of KoanInfo objects, sums the entire
         collection's 'It' blocks and returns a single integer sum.
     .PARAMETER KoanInfo
-        Takes an array of ExternalScriptInfo objects (as provided from Get-Command when
-        passed the path to an external .ps1 script file).
+        Takes an array of KoanInfo objects (as provided from Get-PSKoan).
     .EXAMPLE
         Get-Command .\KoanDirectory\*\*.ps1 | Measure-Koan
 
         422
     .NOTES
-        Measure-Koan is NOT designed to handle dynamic -TestCases values. It will handle
-        simple counts of directly attached -TestCases hashtables only if they do not
-        contain variables, pipelines, and other dynamic expressions.
-
-        Handling dynamic scripts with pipelines and variables is beyond scope and will
-        not be handled; we'd essentially end up reimplementing the PS parser. If it can't
-        be got with .GetSafeValue() we simply aren't working with it.
-
         Author: Joel Sallow
         Module: PSKoans
     .LINK
@@ -38,50 +26,45 @@ function Measure-Koan {
     param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [PSTypeName('PSKoans.KoanInfo')]
-        [object[]]
+        [psobject[]]
         $KoanInfo
     )
     begin {
         $KoanCount = 0
     }
     process {
-        Write-Verbose "Parsing koan files from [$($KoanInfo.Name -join '], [')]"
+        Write-Verbose "Discovering koans in [$($KoanInfo.Name -join '], [')]"
 
-        # Find all Pester 'It' commands
-        $ItCommands = @(Get-KoanIt -Path $KoanInfo.Path)
+        $Result = & (Get-Module Pester) {
+            [CmdletBinding()]
+            param(
+                $Path,
+                $ExcludePath,
+                $SessionState
+            )
 
-        # Find the -TestCases parameters
-        $TestCasesParameters = $ItCommands.Ast.CommandElements | Where-Object {
-            $_ -is [CommandParameterAst] -and
-            $_.ParameterName -eq 'TestCases'
-        }
-
-        if ($TestCasesParameters) {
-            # Get the right CommandElements indexes for their arguments
-            $Indexes = $TestCasesParameters.ForEach{$ItCommands.Ast.CommandElements.IndexOf($_) + 1}
-            # Get value of the argument for each -TestCases
-            $ParameterArgument = $ItCommands.Ast.CommandElements[$Indexes]
-
+            $_Pester_State_Backup = $state.PSObject.Copy()
+            $state.Stack = [System.Collections.Stack]@()
             try {
-                $TestCaseCount = $ParameterArgument.SafeGetValue().Count
-            }
-            catch {
-                # We aren't parsing complex or variable expressions, so exit here (violently)
-                $ParseException = [ParseException]::new(
-                    "Unable to parse unsafe expression in Koan -TestCase syntax.",
-                    $_.Exception
-                )
-                $ErrorRecord = [ErrorRecord]::new(
-                    $ParseException,
-                    "PSKoans.KoanAstParseError",
-                    [ErrorCategory]::ParserError,
-                    $ParameterValues.PipelineElements.Extent.Text
-                )
-                $PSCmdlet.ThrowTerminatingError($ErrorRecord)
-            }
-        }
+                Reset-TestSuiteState
 
-        $KoanCount += $TestCaseCount + $ItCommands.Count - $TestCasesParameters.Count
+                # to avoid Describe thinking that we run in interactive mode
+                $invokedViaInvokePester = $true
+
+                $fileList = Find-File -Path $Path -ExcludePath $ExcludePath -Extension '.Koans.ps1'
+                $containers = foreach ($file in $fileList) {
+                    New-BlockContainerObject -File (Get-Item $file)
+                }
+
+                Find-Test -BlockContainer $containers -SessionState $SessionState
+            }
+            finally {
+                $state = $_Pester_State_Backup
+                Remove-Variable -Name _Pester_State_Backup
+            }
+        } -Path $KoanInfo.Path -SessionState $PSCmdlet.SessionState
+
+        $KoanCount += Measure-KoanTestBlock $Result
     }
     end {
         Write-Verbose "Total Koans: $KoanCount"

--- a/PSKoans/Private/Measure-Koan.ps1
+++ b/PSKoans/Private/Measure-Koan.ps1
@@ -31,6 +31,12 @@
     )
     begin {
         $KoanCount = 0
+        $oldModulePath = $env:PSModulePath
+
+        $env:PSModulePath = @(
+            $MyInvocation.MyCommand.Module.ModuleBase
+            $env:PSModulePath -split [System.IO.Path]::PathSeparator
+        ) -join [System.IO.Path]::PathSeparator
     }
     process {
         Write-Verbose "Discovering koans in [$($KoanInfo.Name -join '], [')]"
@@ -69,5 +75,7 @@
     end {
         Write-Verbose "Total Koans: $KoanCount"
         $KoanCount
+
+        $env:PSModulePath = $oldModulePath
     }
 }

--- a/PSKoans/Private/Measure-KoanBlockTest.ps1
+++ b/PSKoans/Private/Measure-KoanBlockTest.ps1
@@ -1,0 +1,23 @@
+function Measure-KoanTestBlock {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]
+        $Block
+    )
+
+    $Label = if ($Block.Name) {
+        "Block $($Block.Name)"
+    }
+    else {
+        "File $($Block.BlockContainer.Item)"
+    }
+
+    $Count = $Block.Tests.Count
+    foreach ($testBlock in $Block.Blocks) {
+        $Count += Measure-KoanTestBlock $testBlock
+    }
+
+    $Count
+    Write-Information "$Label Tests: $Count"
+}

--- a/PSKoans/Private/New-KoanRunspace.ps1
+++ b/PSKoans/Private/New-KoanRunspace.ps1
@@ -1,0 +1,43 @@
+function New-KoanRunspace {
+    <#
+    .SYNOPSIS
+    Creates a new runspace, with PSKoans and Pester already imported, and PSModulePath already set.
+
+    .DESCRIPTION
+    Creates a new runspace for reuse with Invoke-Koan. The new runspace will be pre-populated with a fresh copy of
+    Pester and PSKoans imported, and with a copy of the current session state's PSModulePath, which will have the
+    current PSKoans parent folder in it, such that `using module` statements will find the current PSKoans module
+    first, avoiding issues with debug environments which may find older PSKoans modules installed instead of using the
+    current debug version.
+
+    .EXAMPLE
+    $script:KoanRunspace = New-KoanRunspace
+
+    .NOTES
+    Run scripts in a new scope to avoid scope bleed wherever possible, with the `$ps.AddScript($script, $true) overload.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $runspace = [runspacefactory]::CreateRunspace()
+    $runspace.Open()
+    $runspace.Name = 'PSKoans.KoanRunspace'
+    $ps = [powershell]::Create($runspace)
+
+    try {
+        $script = {
+            param( $PSKoansPath )
+
+            Get-Module $PSKoansPath -ListAvailable | Import-Module
+        }
+
+        $ps.AddScript($script) > $null
+        $ps.AddParameter('PSKoansPath', $MyInvocation.MyCommand.Module.ModuleBase) > $null
+        $ps.Invoke() > $null
+
+        $runspace
+    }
+    finally {
+        $ps.Dispose()
+    }
+}

--- a/PSKoans/Private/New-PSKoanErrorRecord.ps1
+++ b/PSKoans/Private/New-PSKoanErrorRecord.ps1
@@ -40,7 +40,7 @@ function New-PSKoanErrorRecord {
     #>
 
     [CmdletBinding(DefaultParameterSetName = 'Default')]
-    [OutputType([ErrorRecord])]
+    [OutputType([System.Management.Automation.ErrorRecord])]
     param(
         [Parameter(ParameterSetName = 'Default')]
         [Alias('Type')]
@@ -73,8 +73,8 @@ function New-PSKoanErrorRecord {
 
         [Parameter()]
         [Alias('Category')]
-        [ErrorCategory]
-        $ErrorCategory = [ErrorCategory]::NotSpecified,
+        [System.Management.Automation.ErrorCategory]
+        $ErrorCategory = [System.Management.Automation.ErrorCategory]::NotSpecified,
 
         [Parameter()]
         [PSObject]
@@ -89,7 +89,7 @@ function New-PSKoanErrorRecord {
             $ErrorId = "PSKoans.$($ErrorId)"
         }
 
-        [ErrorRecord]::new(
+        [System.Management.Automation.ErrorRecord]::new(
             $Exception,
             $ErrorId,
             $ErrorCategory,

--- a/README.md
+++ b/README.md
@@ -57,16 +57,11 @@ To install the latest version of Pester, use the appropriate command for your ve
 
 ```PowerShell
 # PS 5.1 (upgrade to latest Pester)
-Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MaximumVersion 4.99.99
+Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.2
 
 # PS 6.0+ (Install Pester under current user)
-Install-Module Pester -Scope CurrentUser -MaximumVersion 4.99.99
+Install-Module Pester -Scope CurrentUser -MinimumVersion 5.0.2
 ```
-
-> :warning: **WARNING**
->
-> PSKoans is not yet compatible with v5 of Pester, and I have (unwisely) neglected to set the -MaximumVersion in the PSKoans module manifest as yet.
-> I will make some fixes shortly, but in the meantime you cannot have v5 of Pester installed if you would like to use PSKoans.
 
 ## Getting Started
 

--- a/Tests/Functions/Private/ConvertFrom-WildcardPattern.Tests.ps1
+++ b/Tests/Functions/Private/ConvertFrom-WildcardPattern.Tests.ps1
@@ -1,29 +1,26 @@
 #Requires -Modules PSKoans
 
-InModuleScope 'PSKoans' {
-    Describe 'ConvertFrom-WildcardPattern' {
+Describe 'ConvertFrom-WildcardPattern' {
 
-        It 'adds start and end of string anchors to an explicit value' {
-            ConvertFrom-WildcardPattern 'AboutArrays' | Should -Be '^AboutArrays$'
-        }
+    It 'adds start and end of string anchors to an explicit value' {
+        InModuleScope 'PSKoans' { ConvertFrom-WildcardPattern 'AboutArrays' } | Should -Be '^AboutArrays$'
+    }
 
-        It 'joins multiple expressions with or' {
-            ConvertFrom-WildcardPattern 'AboutArrays', 'AboutComparison' | Should -Be '^AboutArrays$|^AboutComparison$'
-        }
+    It 'joins multiple expressions with |' {
+        InModuleScope 'PSKoans' { ConvertFrom-WildcardPattern 'AboutArrays', 'AboutComparison' } |
+            Should -Be '^AboutArrays$|^AboutComparison$'
+    }
 
+    It 'replaces wildcard characters with regex equivalent' -TestCases @(
+        @{ Pattern = 'About*son'; Expected = '^About.*son$' }
+        @{ Pattern = 'AboutArrays*'; Expected = '^AboutArrays' }
+        @{ Pattern = '*Arrays'; Expected = 'Arrays$' }
+        @{ Pattern = '*Array*'; Expected = 'Array' }
+    ) {
+        InModuleScope 'PSKoans' -Parameters @{ Pattern = $Pattern } {
+            param($Pattern)
 
-        It 'Replaces wildcard characters with regex equivalent' -TestCases @(
-            @{ Pattern = 'About*son';    Expected = '^About.*son$' }
-            @{ Pattern = 'AboutArrays*'; Expected = '^AboutArrays' }
-            @{ Pattern = '*Arrays';      Expected = 'Arrays$' }
-            @{ Pattern = '*Array*';      Expected = 'Array' }
-        ) {
-            param (
-                $Pattern,
-                $Expected
-            )
-
-            ConvertFrom-WildcardPattern $Pattern | Should -Be $Expected
-        }
+            ConvertFrom-WildcardPattern $Pattern
+        } | Should -Be $Expected
     }
 }

--- a/Tests/Functions/Private/Measure-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Measure-Koan.Tests.ps1
@@ -1,96 +1,90 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-   $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe 'Measure-Koan' -Skip {
 
-InModuleScope 'PSKoans' {
-    Describe 'Measure-Koan' {
-        BeforeAll {
-            Set-Content -Path TestDrive:\TestCases.Koans.ps1 -Value @'
-                Describe 'Test cases param' {
-                    It 'first <TestCase>' -TestCases @(
-                        @{ TestCase = 1 }
-                        @{ TestCase = 2 }
-                        @{ TestCase = 3 }
-                    ) {
-                        param($TestCase)
+    BeforeAll {
+        Set-Content -Path 'TestDrive:\TestCases.Koans.ps1' -Value @'
+            Describe 'Test cases param' {
+                It 'first <TestCase>' -TestCases @(
+                    @{ TestCase = 1 }
+                    @{ TestCase = 2 }
+                    @{ TestCase = 3 }
+                ) {
+                    param($TestCase)
 
-                        $TestCase | Should -BeOfType int
-                    }
+                    $TestCase | Should -BeOfType int
                 }
-'@
-
-                Set-Content -Path TestDrive:\JustIt.Koans.ps1 -Value @'
-                    Describe 'Just it' {
-                        It 'first' {
-                            $true | Should -BeTrue
-                        }
-
-                        It 'second' {
-                            $true | Should -BeTrue
-                        }
-                    }
-'@
-
-                Set-Content -Path TestDrive:\Mixed.Koans.ps1 -Value @'
-                    Describe 'Mixed' {
-                        It 'first' {
-                            $true | Should -BeTrue
-                        }
-
-                        It 'second <TestCase>' -TestCases @(
-                            @{ TestCase = 1 }
-                            @{ TestCase = 2 }
-                        ) {
-                            param($TestCase)
-
-                            $TestCase | Should -BeOfType int
-                        }
-                    }
-'@
-
-                Set-Content -Path TestDrive:\MutlipleTestCases.Koans.ps1 -Value @'
-                    Describe 'Test cases param' {
-                        It 'first <TestCase>' -TestCases @(
-                            @{ TestCase = 1 }
-                            @{ TestCase = 2 }
-                            @{ TestCase = 3 }
-                        ) {
-                            param($TestCase)
-
-                            $TestCase | Should -BeOfType int
-                        }
-
-                        It 'second <TestCase>' -TestCases @(
-                            @{ TestCase = 1 }
-                            @{ TestCase = 2 }
-                            @{ TestCase = 3 }
-                        ) {
-                            param($TestCase)
-
-                            $TestCase | Should -BeOfType int
-                        }
-                    }
-'@
-        }
-
-        It 'counts the number of tests in <Path>' -TestCases @(
-            @{ Path = 'TestDrive:\TestCases.Koans.ps1';         ExpectedValue = 3 }
-            @{ Path = 'TestDrive:\JustIt.Koans.ps1';            ExpectedValue = 2 }
-            @{ Path = 'TestDrive:\Mixed.Koans.ps1';             ExpectedValue = 3 }
-            @{ Path = 'TestDrive:\MutlipleTestCases.Koans.ps1'; ExpectedValue = 6 }
-        ) {
-            param($Path, $ExpectedValue)
-
-            $koanInfo = [PSCustomObject]@{
-                Path       = $Path
-                PSTypeName = 'PSKoans.KoanInfo'
             }
+'@
 
-            $koanInfo | Measure-Koan | Should -Be $ExpectedValue
+        Set-Content -Path 'TestDrive:\JustIt.Koans.ps1' -Value @'
+            Describe 'Just it' {
+                It 'first' {
+                    $true | Should -BeTrue
+                }
+
+                It 'second' {
+                    $true | Should -BeTrue
+                }
+            }
+'@
+
+        Set-Content -Path TestDrive:\Mixed.Koans.ps1 -Value @'
+            Describe 'Mixed' {
+                It 'first' {
+                    $true | Should -BeTrue
+                }
+
+                It 'second <TestCase>' -TestCases @(
+                    @{ TestCase = 1 }
+                    @{ TestCase = 2 }
+                ) {
+                    param($TestCase)
+
+                    $TestCase | Should -BeOfType int
+                }
+            }
+'@
+
+        Set-Content -Path TestDrive:\MutlipleTestCases.Koans.ps1 -Value @'
+            Describe 'Test cases param' {
+                It 'first <TestCase>' -TestCases @(
+                    @{ TestCase = 1 }
+                    @{ TestCase = 2 }
+                    @{ TestCase = 3 }
+                ) {
+                    param($TestCase)
+
+                    $TestCase | Should -BeOfType int
+                }
+
+                It 'second <TestCase>' -TestCases @(
+                    @{ TestCase = 1 }
+                    @{ TestCase = 2 }
+                    @{ TestCase = 3 }
+                ) {
+                    param($TestCase)
+
+                    $TestCase | Should -BeOfType int
+                }
+            }
+'@
+    }
+
+    It 'correctly counts the number of tests in <Path>, including -TestCases' -TestCases @(
+        @{ Path = 'TestDrive:\TestCases.Koans.ps1'; ExpectedValue = 3 }
+        @{ Path = 'TestDrive:\JustIt.Koans.ps1'; ExpectedValue = 2 }
+        @{ Path = 'TestDrive:\Mixed.Koans.ps1'; ExpectedValue = 3 }
+        @{ Path = 'TestDrive:\MutlipleTestCases.Koans.ps1'; ExpectedValue = 6 }
+    ) {
+        $koanInfo = [PSCustomObject]@{
+            Path       = $Path
+            PSTypeName = 'PSKoans.KoanInfo'
         }
+
+        InModuleScope 'PSKoans' -Parameters @{ Koan = $koanInfo } {
+            param($Koan)
+            Measure-Koan $Koan
+        } | Should -Be $ExpectedValue
     }
 }

--- a/Tests/Functions/Private/New-KoanRunspace.Tests.ps1
+++ b/Tests/Functions/Private/New-KoanRunspace.Tests.ps1
@@ -1,0 +1,34 @@
+Describe 'New-KoanRunspace' {
+
+    BeforeAll {
+        [runspace]$runspace = $null
+    }
+
+    AfterEach {
+        $runspace.Dispose()
+    }
+
+    It 'creates a new runspace' {
+        $runspace = InModuleScope 'PSKoans' { New-KoanRunspace }
+        $runspace | Should -BeOfType [runspace]
+    }
+
+    It 'names the new runspace' {
+        $runspace = InModuleScope 'PSKoans' { New-KoanRunspace }
+        $runspace.Name | Should -Be 'PSKoans.KoanRunspace'
+    }
+
+    It 'preloads the runspace with PSKoans' {
+        $runspace = InModuleScope 'PSKoans' { New-KoanRunspace }
+        $ps = [powershell]::Create($runspace)
+
+        try {
+            $ps.AddCommand('Get-Module').AddParameter('Name', 'PSKoans') > $null
+            $module = $ps.Invoke()
+            $module.Name | Should -eq 'PSKoans'
+        }
+        finally {
+            $ps.Dispose()
+        }
+    }
+}

--- a/Tests/Functions/Private/Update-PSKoanFile.Tests.ps1
+++ b/Tests/Functions/Private/Update-PSKoanFile.Tests.ps1
@@ -1,86 +1,81 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe 'Update-PSKoanFile' {
 
-InModuleScope 'PSKoans' {
-    Describe 'Update-PSKoanFile' {
-        BeforeAll {
-            Mock Get-PSKoanLocation {
-                Join-Path -Path $TestDrive -ChildPath 'Koans'
+    BeforeAll {
+        Mock 'Get-PSKoanLocation' {
+            Join-Path -Path $TestDrive -ChildPath 'Koans'
+        }
+
+        Mock 'Get-PSKoan' {
+            [PSCustomObject]@{
+                Topic        = 'AboutSomething'
+                Path         = Join-Path -Path $TestDrive -ChildPath 'Module/Group/AboutSomething.ps1'
+                RelativePath = 'Group/AboutSomething.ps1'
             }
-            Mock Get-PSKoan {
-                [PSCustomObject]@{
-                    Topic        = 'AboutSomething'
-                    Path         = Join-Path -Path $TestDrive -ChildPath 'Module/Group/AboutSomething.ps1'
-                    RelativePath = 'Group/AboutSomething.ps1'
+        }
+
+        New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Koans/Group') -ItemType Directory
+        New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Module/Group') -ItemType Directory
+
+        Set-Content -Path (Get-PSKoan).Path -Value @'
+            Describe 'AboutSomething' {
+                It 'koan 1' {
+                    __ | Should -Be 1
                 }
-            }
-            New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Koans/Group') -ItemType Directory
-            New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Module/Group') -ItemType Directory
 
-            Set-Content -Path (Get-PSKoan).Path -Value @'
-                Describe 'AboutSomething' {
-                    It 'koan 1' {
-                        __ | Should -Be 1
-                    }
+                It 'koan 2' {
+                    __ | Should -Be 2
+                }
 
-                    It 'koan 2' {
-                        __ | Should -Be 2
-                    }
-
-                    Context 'first' {
-                        It 'koan 3' {
-                            __ | Should -Be 3
-                        }
-                    }
-
-                    Context 'second' {
-                        It 'koan 4' {
-                            __ | Should -Be 4
-                        }
+                Context 'first' {
+                    It 'koan 3' {
+                        __ | Should -Be 3
                     }
                 }
+
+                Context 'second' {
+                    It 'koan 4' {
+                        __ | Should -Be 4
+                    }
+                }
+            }
 '@
 
-            $userFilePath = Join-Path -Path (Get-PSKoanLocation) -ChildPath (Get-PSKoan).RelativePath
-        }
+        $userFilePath = Join-Path -Path (Get-PSKoanLocation) -ChildPath (Get-PSKoan).RelativePath
+    }
 
-        BeforeEach {
-            Set-Content -Path $userFilePath -Value @'
-                Describe 'AboutSomething' {
-                    It 'koan 1' {
-                        1 | Should -Be 1
-                    }
+    BeforeEach {
+        Set-Content -Path $userFilePath -Value @'
+            Describe 'AboutSomething' {
+                It 'koan 1' {
+                    1 | Should -Be 1
+                }
 
-                    It 'koan 2' {
-                        __ | Should -Be 2
-                    }
+                It 'koan 2' {
+                    __ | Should -Be 2
+                }
 
-                    Context 'second' {
-                        It 'koan 4' {
-                            4 | Should -Be 4
-                        }
+                Context 'second' {
+                    It 'koan 4' {
+                        4 | Should -Be 4
                     }
                 }
+            }
 '@
-        }
+    }
 
-        It 'should replay completed koans' {
-            Update-PSKoanFile -Topic AboutSomething -Confirm:$false
+    It 'should replay completed koans' {
+        InModuleScope 'PSKoans' { Update-PSKoanFile -Topic AboutSomething -Confirm:$false }
 
-            $userFilePath | Should -FileContentMatch '1 | Should -Be 1'
-            $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
-            $userFilePath | Should -FileContentMatch '4 | Should -Be 4'
-        }
+        $userFilePath | Should -FileContentMatch '1 | Should -Be 1'
+        $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
+        $userFilePath | Should -FileContentMatch '4 | Should -Be 4'
+    }
 
-        It 'should should allow new koans to be inserted' {
-            Update-PSKoanFile -Topic AboutSomething -Confirm:$false
+    It 'should should allow new koans to be inserted' {
+        InModuleScope 'PSKoans' { Update-PSKoanFile -Topic AboutSomething -Confirm:$false }
 
-            $userFilePath | Should -FileContentMatch 'koan 3'
-        }
+        $userFilePath | Should -FileContentMatch 'koan 3'
     }
 }

--- a/Tests/Functions/Public/Get-Blank.Tests.ps1
+++ b/Tests/Functions/Public/Get-Blank.Tests.ps1
@@ -1,14 +1,15 @@
 #Requires -Modules PSKoans
 
 Describe 'Get-Blank' {
+
     It 'should not produce output' {
         Get-Blank | Should -BeNullOrEmpty
     }
-    
+
     It 'should be usable in the middle of a pipeline' {
         { Get-Variable | Get-Blank | Write-Output } | Should -Not -Throw
     }
-    
+
     It 'should quietly ignore parameters' {
         { Get-Blank -Param1 Value1 -Param2 Value2 } | Should -Not -Throw
     }

--- a/Tests/Functions/Public/Get-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Get-Karma.Tests.ps1
@@ -1,156 +1,165 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe 'Get-Karma' {
 
-InModuleScope 'PSKoans' {
-    Describe 'Get-Karma' {
+    BeforeAll {
+        $originalLocation = Get-PSKoanLocation
+        Set-PSKoanLocation -Path (Join-Path $TestDrive -ChildPath 'PSKoans')
+        Update-PSKoan -Confirm:$false
+    }
+
+    AfterAll {
+        Set-PSKoanLocation -Path $originalLocation
+    }
+
+    Context 'Default Behaviour' {
+
         BeforeAll {
-            $TestLocation = Join-Path -Path $TestDrive -ChildPath 'PSKoans'
-
-            Mock Get-PSKoanLocation {
-                $TestLocation
-            }
-
-            Update-PSKoan -Confirm:$false
-        }
-
-        Context 'Default Behaviour' {
-            BeforeAll {
-                Mock Invoke-Koan -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{
-                        PassedCount = 0
-                        FailedCount = 4
-                    }
+            Mock 'Measure-Koan' -MockWith { 4 } -ModuleName 'PSKoans'
+            Mock 'Invoke-Koan' -ModuleName 'PSKoans' {
+                [PSCustomObject]@{
+                    PassedCount = 0
+                    FailedCount = 4
+                    Failed      = @()
                 }
             }
 
-            It 'should produce a hashtable with data' {
-                $Result = Get-Karma
-                $Result.PSTypeNames[0] | Should -Be 'PSKoans.Result'
-                $Result.KoansPassed | Should -Be 0
-            }
-
-            It 'should Invoke-Pester on koans until it fails a test' {
-                Assert-MockCalled Invoke-Koan -Times 1
-            }
-
-            It 'should populate the $script:CurrentTopic variable' {
-                $script:CurrentTopic | Should -BeOfType [hashtable]
-                $script:CurrentTopic.Count | Should -Be 4
-                @('Name', 'Completed', 'Total', 'CurrentLine') | Should -BeIn $script:CurrentTopic.Keys
-            }
+            $Result = Get-Karma
         }
 
-        Context 'With Nonexistent Koans Folder / No Koans Found' {
-            BeforeAll {
-                Mock Measure-Koan -ModuleName 'PSKoans' { }
-                Mock Update-PSKoan -ModuleName 'PSKoans' { throw 'Prevent recursion' }
-                Mock Write-Warning
-            }
-
-            It 'should attempt to populate koans and then recurse to reassess' {
-                { Get-Karma } | Should -Throw -ExpectedMessage 'Prevent recursion'
-            }
-
-            It 'should display a warning before initiating a reset' {
-                Assert-MockCalled Write-Warning
-            }
-
-            It 'throws an error if a Topic is specified that matches nothing' {
-                { Get-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound'
-            }
+        It 'produces a hashtable with data' {
+            $Result.PSTypeNames[0] | Should -Be 'PSKoans.Result'
+            $Result.KoansPassed | Should -Be 0
         }
 
-        Context 'With -ListTopics Parameter' {
-            BeforeAll {
-                Mock Get-PSKoan { }
-            }
-
-            It 'should list all the koan topics' {
-                Get-Karma -ListTopics
-
-                Assert-MockCalled Get-PSKoan
-            }
+        It 'calls Measure-Koan on each file to count koans' {
+            Should -Invoke 'Measure-Koan' -Scope Context -ModuleName 'PSKoans'
         }
 
-        Context 'With -Topic Parameter' {
-            BeforeAll {
-                Mock Invoke-Koan -ModuleName 'PSKoans' { }
-            }
-
-            It 'should Invoke-Pester on only the topics selected: <Topic>' -TestCases @(
-                @{ Topic = @( 'AboutAssertions' ) }
-                @{ Topic = @( 'AboutArrays', 'AboutConditionals', 'AboutComparison' ) }
-            ) {
-                param([string[]] $Topic)
-
-                Get-Karma -Topic $Topic
-
-                Assert-MockCalled Invoke-Koan -Times @($Topic).Count
-            }
+        It 'calls Invoke-Koan on each topic file until it fails a test' {
+            Should -Invoke 'Invoke-Koan' -Times 1 -ModuleName 'PSKoans' -Scope Context
         }
 
-        Context 'Behaviour When All Koans Are Completed' {
-            BeforeAll {
-                Mock Get-PSKoanLocation {
-                    Join-Path -Path $TestDrive -ChildPath 'CompletedKoan'
-                }
+        It 'populates the $script:CurrentTopic variable' {
+            $currentTopic = InModuleScope 'PSKoans' { $script:CurrentTopic }
+            $currentTopic | Should -BeOfType [hashtable]
+            $currentTopic.Count | Should -Be 4
+            @('Name', 'Completed', 'Total', 'CurrentLine') | Should -BeIn $currentTopic.Keys
+        }
+    }
 
-                $TestFile = Join-Path -Path (Get-PSKoanLocation) -ChildPath 'Group\SelectedTopicTest.Koans.Ps1'
-                New-Item -Path (Split-Path $TestFile -Parent) -ItemType Directory -Force
-                Set-Content -Path $TestFile -Value @'
-                    using module PSKoans
-                    [Koan(Position = 1)]
-                    param()
+    Context 'With Nonexistent Koans Folder / No Koans Found' {
 
-                    Describe 'Koans Test' {
+        BeforeAll {
+            Mock 'Measure-Koan' -ModuleName 'PSKoans'
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'User' }
+            Mock 'Update-PSKoan' { throw 'Prevent recursion' }
+            Mock 'Write-Warning'
+        }
 
-                        It 'is easy to solve' {
-                            $true | Should -BeTrue
-                        }
+        It 'should attempt to populate koans and then recurse to reassess' {
+            { Get-Karma } | Should -Throw -ExpectedMessage 'Prevent recursion'
+            Should -Invoke 'Update-PSKoan' -Scope Context
+        }
 
-                        It 'is positively trivial' {
-                            $false | Should -BeFalse
-                        }
+        It 'displays a warning before initiating a reset' {
+            Should -Invoke 'Write-Warning' -Scope Context
+        }
+
+        It 'throws an error if a Topic is specified that matches nothing' {
+            { Get-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound,Get-Karma'
+        }
+    }
+
+    Context 'With -ListTopics Parameter' {
+
+        BeforeAll {
+            Mock 'Get-PSKoan'
+        }
+
+        It 'lists all the koan topics' {
+            Get-Karma -ListTopics
+
+            Should -Invoke 'Get-PSKoan'
+        }
+    }
+
+    Context 'With -Topic Parameter' {
+
+        BeforeAll {
+            Mock 'Measure-Koan' -ModuleName 'PSKoans' { [int]::MaxValue }
+            Mock 'Invoke-Koan' -ModuleName 'PSKoans'
+        }
+
+        It 'calls Invoke-Koan on only the topics selected: <Topic>' -TestCases @(
+            @{ Topic = @( 'AboutAssertions' ) }
+            @{ Topic = @( 'AboutArrays', 'AboutConditionals', 'AboutComparison' ) }
+        ) {
+            Get-Karma -Topic $Topic
+
+            Should -Invoke 'Invoke-Koan' -Times @($Topic).Count -ModuleName 'PSKoans'
+        }
+    }
+
+    Context 'Behaviour When All Koans Are Completed' {
+
+        BeforeAll {
+            Mock 'Get-PSKoanLocation' {
+                Join-Path -Path $TestDrive -ChildPath 'CompletedKoan'
+            }
+
+            Mock 'Measure-Koan' -ModuleName 'PSKoans' -MockWith { 2 }
+
+            $TestFile = Join-Path -Path (Get-PSKoanLocation) -ChildPath 'Group\SelectedTopicTest.Koans.ps1'
+            New-Item -Path (Split-Path $TestFile -Parent) -ItemType Directory -Force
+            Set-Content -Path $TestFile -Value @'
+                using module PSKoans
+                [Koan(Position = 1)]
+                param()
+
+                Describe 'Koans Test' {
+
+                    It 'is easy to solve' {
+                        $true | Should -BeTrue
                     }
+
+                    It 'is positively trivial' {
+                        $false | Should -BeFalse
+                    }
+                }
 '@
 
-                try {
-                    $Result = Get-Karma -Topic SelectedTopicTest
-                }
-                catch {
-                    # Ignore this. Error tests follow.
-                }
+            try {
+                $Result = Get-Karma -Topic SelectedTopicTest
             }
+            catch {
+                # Ignore this. Error tests follow.
+            }
+        }
 
-            It 'should not divide by zero if all Koans are completed' {
-                { Get-Karma -Topic SelectedTopicTest } | Should -Not -Throw
-            }
+        It 'does not divide by zero if all Koans are completed' {
+            { Get-Karma -Topic SelectedTopicTest } | Should -Not -Throw
+        }
 
-            It 'should output the result object' {
-                $Result | Should -Not -BeNullOrEmpty
-                $Result.PSTypeNames | Should -Contain 'PSKoans.CompleteResult'
-            }
+        It 'outputs the result object' {
+            $Result | Should -Not -BeNullOrEmpty
+            $Result.PSTypeNames | Should -Contain 'PSKoans.CompleteResult'
+        }
 
-            It 'should indicate completion' {
-                $Result.Complete | Should -BeTrue
-            }
+        It 'indicates completion' {
+            $Result.Complete | Should -BeTrue
+        }
 
-            It 'should indicate number of koans passed' {
-                $Result.KoansPassed | Should -Be 2
-            }
+        It 'indicates number of koans passed' {
+            $Result.KoansPassed | Should -Be 2
+        }
 
-            It 'should indicate total number of koans' {
-                $Result.TotalKoans | Should -Be 2
-            }
+        It 'indicates total number of koans' {
+            $Result.TotalKoans | Should -Be 2
+        }
 
-            It 'should indicate the requested topic' {
-                $Result.RequestedTopic | Should -Be 'SelectedTopicTest'
-            }
+        It 'indicates the requested topic' {
+            $Result.RequestedTopic | Should -Be 'SelectedTopicTest'
         }
     }
 }

--- a/Tests/Functions/Public/Get-PSKoan.Tests.ps1
+++ b/Tests/Functions/Public/Get-PSKoan.Tests.ps1
@@ -1,76 +1,63 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe 'Get-PSKoan' {
 
-InModuleScope PSKoans {
-    Describe 'Get-PSKoan' {
-        BeforeAll {
-            Mock Get-PSKoanLocation {
-                Join-Path $TestDrive 'PSKoans'
-            }
+    BeforeAll {
+        Mock 'Get-PSKoanLocation' {
+            Join-Path $TestDrive 'PSKoans'
+        }
 
-            Update-PSKoan -Confirm:$false
+        Update-PSKoan -Confirm:$false
 
-            # Stage test module
-            $path = Join-Path -Path (Get-PSKoanLocation) 'Modules\TestModule'
-            New-Item -Path $path -ItemType Directory -Force
-            Set-Content -Path (Join-Path -Path $path -ChildPath 'AboutSomething.Koans.ps1') -Value @'
-                using module PSKoans
-                [Koan(Position = 1, Module = 'TestModule')]
-                param( )
+        # Stage test module
+        $path = Join-Path -Path (Get-PSKoanLocation) 'Modules\TestModule'
+        New-Item -Path $path -ItemType Directory -Force
+        Set-Content -Path (Join-Path -Path $path -ChildPath 'AboutSomething.Koans.ps1') -Value @'
+            using module PSKoans
+            [Koan(Position = 1, Module = 'TestModule')]
+            param()
 
-                Describe 'AboutSomething' {
-                    It 'first' {
-                        $true | Should -BeTrue
-                    }
+            Describe 'AboutSomething' {
+                It 'first' {
+                    $true | Should -BeTrue
                 }
+            }
 '@
-        }
+    }
 
-        It 'should retrieve all except module-specific koan files' {
-            $Files = Get-ChildItem -Path (Get-PSKoanLocation) -Filter *.Koans.ps1 -Recurse -File |
-                Where-Object FullName -notmatch 'PSKoans[\\/]Modules[\\/]'
+    It 'retrieves all except module-specific koan files' {
+        $Files = Get-ChildItem -Path (Get-PSKoanLocation) -Filter *.Koans.ps1 -Recurse -File |
+            Where-Object FullName -NotMatch 'PSKoans[\\/]Modules[\\/]'
 
-            (Get-PSKoan).Topic.Count | Should -Be $Files.Count
-        }
+        (Get-PSKoan).Topic.Count | Should -Be $Files.Count
+    }
 
-        It 'should retrieve specific requested files with -Topic <Topic>' -TestCases @(
-            @{ Topic = 'AboutArrays' }
-            @{ Topic = 'AboutVariables' }
-            @{ Topic = 'AboutTypeOperators' }
-            @{ Topic = 'AboutLists' }
-            @{ Topic = 'AboutVariables', 'AboutLists' }
-        ) {
-            param($Topic)
+    It 'retrieves specific requested files with -Topic <Topic>' -TestCases @(
+        @{ Topic = 'AboutArrays' }
+        @{ Topic = 'AboutVariables' }
+        @{ Topic = 'AboutTypeOperators' }
+        @{ Topic = 'AboutLists' }
+        @{ Topic = 'AboutVariables', 'AboutLists' }
+    ) {
+        (Get-PSKoan -Topic $Topic).Topic | Should -Be $Topic
+    }
 
-            (Get-PSKoan -Topic $Topic).Topic | Should -Be $Topic
-        }
+    It 'retrieves specific requested files with -Module <Module>' -TestCases @(
+        @{ Topic = 'AboutSomething'; Module = 'TestModule' }
+    ) {
+        (Get-PSKoan -Module $Module -Scope User).Topic | Should -Be $Topic
+    }
 
-        It 'should retrieve specific requested files with -Module <Module>' -TestCases @(
-            @{ Topic = 'AboutSomething'; Module = 'TestModule' }
-        ) {
-            param($Topic, $Module)
+    It 'should throw a terminating error if a file is blocked' -Skip:($PSVersionTable.PSEdition -ne 'Desktop' -or $PSVersionTable.Platform -ne 'Win32NT') {
+        $testFile = Get-ChildItem -Path (Get-PSKoanLocation) -Filter AboutArrays.Koans.ps1 -Recurse -File |
+            Select-Object -First 1
 
-            (Get-PSKoan -Module $Module -Scope User).Topic | Should -Be $Topic
-        }
-
-        if ($PSVersionTable.PSEdition -eq 'Desktop' -or $PSVersionTable.Platform -eq 'Win32NT') {
-            It 'should throw a terminating error if a file is blocked' {
-                $testFile = Get-ChildItem -Path (Get-PSKoanLocation) -Filter AboutArrays.Koans.ps1 -Recurse -File |
-                    Select-Object -First 1
-
-                Set-Content -Path $testFile.FullName -Stream Zone.Identifier -Value @'
+        Set-Content -Path $testFile.FullName -Stream Zone.Identifier -Value @'
                     [ZoneTransfer]
                     ZoneId=3
                     ReferrerUrl=C:\Downloads\File.zip
 '@
 
-                { Get-PSKoan -Topic AboutArrays -Scope User } | Should -Throw -ErrorId PSKoans.KoanFileIsBlocked
-            }
-        }
+        { Get-PSKoan -Topic AboutArrays -Scope User } | Should -Throw -ErrorId PSKoans.KoanFileIsBlocked
     }
 }

--- a/Tests/Functions/Public/Get-PSKoanLocation.Tests.ps1
+++ b/Tests/Functions/Public/Get-PSKoanLocation.Tests.ps1
@@ -1,23 +1,34 @@
 ﻿#Requires -Modules PSKoans
 
 Describe 'Get-PSKoanLocation' {
-    BeforeAll {
-        Mock Get-PSKoanSetting -ModuleName PSKoans {
-            '~/PSKoans'
-        } -ParameterFilter { $Name -eq 'KoanLocation' }
+
+    Context 'Normal Behaviour' {
+
+        BeforeAll {
+            Mock 'Get-PSKoanSetting' -ParameterFilter { $Name -eq 'KoanLocation' } -MockWith {
+                '~/PSKoans'
+            }
+
+            $Result = Get-PSKoanLocation
+        }
+
+        It 'retrieves the koan library location' {
+            $Result | Should -Be '~/PSKoans'
+        }
+
+        It 'calls Get-PSKoanSetting with -Name "KoanLocation"' {
+            Should -Invoke 'Get-PSKoanSetting' -Scope Context
+        }
     }
 
-    It 'retrieves the koan library location' {
-        Get-PSKoanLocation | Should -Be '~/PSKoans'
-    }
+    Context 'No Value Available' {
 
-    It 'calls Get-PSKoanSetting with -Name "LibraryFolder"' {
-        Assert-MockCalled Get-PSKoanSetting -ModuleName PSKoans
-    }
+        BeforeAll {
+            Mock 'Get-PSKoanSetting' -ParameterFilter { $Name -eq 'KoanLocation' }
+        }
 
-    It 'throws an error if no value can be retrieved' {
-        Mock Get-PSKoanSetting -ModuleName PSKoans -ParameterFilter { $Name -eq 'KoanLocation' }
-
-        { Get-PSKoanLocation } | Should -Throw -ExpectedMessage 'location has not been defined'
+        It 'throws an error if no value can be retrieved' {
+            { Get-PSKoanLocation } | Should -Throw -ExpectedMessage 'PSKoans folder location has not been defined'
+        }
     }
 }

--- a/Tests/Functions/Public/Register-Advice.Tests.ps1
+++ b/Tests/Functions/Public/Register-Advice.Tests.ps1
@@ -1,55 +1,62 @@
 #Requires -Modules PSKoans
 
+Describe "Register-Advice" {
 
-InModuleScope 'PSKoans' {
-    Describe "Register-Advice" {   
-        Context "Checkin the Behaviour if ProfileFolder and ProfilePath Not exists" {
-            BeforeAll{
-                Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfileFolder }
-                Mock New-Item { }
-                Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfilePath }
-                Mock Set-Content { } -ParameterFilter { $Value -eq "Show-Advice" }
-            }
-            It "First Step Test-Path Fails and Create a Item" {
-                Register-Advice
-                Assert-MockCalled -CommandName Test-Path 
-            }
-            It "Second Step Profile Path fails adding content in the file" {
-                Register-Advice
-                Assert-MockCalled -CommandName Set-Content -Times 1
-            }
+    Context "Profile Folder/File Missing" {
+
+        BeforeAll {
+            Mock New-Item -Verifiable
+            Mock Test-Path { $false } -Verifiable
+            Mock Set-Content -ParameterFilter { $Value -eq "Show-Advice" } -Verifiable
         }
-        Context "Checkin the Function with other Possible values" {
-            BeforeAll{
-                Mock Test-Path { $true } -ParameterFilter { $Path -eq $ProfilePath }
-                Mock Select-String { $false }
-                Mock Add-Content { }
-            }
-            It "Third Step If file exists but not having the content (Get|Set)-Advice" {
-                Register-Advice
-                Assert-MockCalled -CommandName Add-Content
-            }
+
+        It 'should create the $profile if it does not exist' {
+            Register-Advice
+            Should -InvokeVerifiable
         }
-        Context "Checkin the behaviour of function with different parameter values" {
-            BeforeAll{
-                Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfileFolder }
-                Mock New-Item { }
-                Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfilePath }
-                Mock Set-Content { } -ParameterFilter { $Value -eq "Show-Advice" }
+    }
+
+    Context "Profile Already Exists" {
+
+        BeforeAll {
+            Mock 'Test-Path' { $true } -Verifiable
+            Mock 'Select-String' { $false } -Verifiable
+            Mock 'Add-Content' -Verifiable
+        }
+
+        It "adds content to the profile if it already exists (Get|Set)-Advice" {
+            Register-Advice
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context "Parameter Validation" {
+
+        BeforeAll {
+            Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfileFolder }
+            Mock New-Item
+            Mock Test-Path { $false } -ParameterFilter { $Path -eq $ProfilePath }
+            Mock Set-Content -ParameterFilter { $Value -eq "Show-Advice" }
+        }
+
+        It "throws if an invalid value is supplied for -TargetProfile" {
+            { Register-Advice -TargetProfile "Invalidvalue" } | Should -Throw
+        }
+
+        It "works correctly with the <ProfilePath> profile" -TestCases @(
+            @{ ProfilePath = 'AllUsersAllHosts' }
+            @{ ProfilePath = 'AllUsersCurrentHost' }
+            @{ ProfilePath = 'CurrentUserAllHosts' }
+            @{ ProfilePath = 'CurrentUserCurrentHost' }
+        ) {
+            try {
+                Register-Advice $ProfilePath | Should -BeNullOrEmpty
             }
-            It "Should throw if invalid parameter(Targetprofile) value is passed" {
-                { Register-Advice -TargetProfile "Invalidvalue" } | Should -Throw
-            }
-            $testdata = @(
-                @{ ProfilePath = 'AllUsersAllHosts' }
-                @{ ProfilePath = 'AllUsersCurrentHost' }
-                @{ ProfilePath = 'CurrentUserAllHosts' }
-                @{ ProfilePath = 'CurrentUserCurrentHost' }
-            )
-            It "Checking with the possible Parameter Values" -TestCases $testdata {
-                param($ProfilePath)
-                Register-Advice $ProfilePath | Should -BeNullOrEmpty 
-            
+            catch [UnauthorizedAccessException] {
+                # Current user doesn't have access to the profile path. This can be normal for the 'AllUsers' paths.
+                if ($ProfilePath -notmatch '^AllUsers') {
+                    throw $_
+                }
             }
         }
     }

--- a/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
+++ b/Tests/Functions/Public/Reset-PSKoan.Tests.ps1
@@ -1,206 +1,211 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe Reset-PSKoan {
 
-InModuleScope PSKoans {
-    Describe Reset-PSKoan {
-        BeforeAll {
-            $defaultParams = @{
-                Confirm = $false
+    BeforeAll {
+        $defaultParams = @{
+            Confirm = $false
+        }
+
+        Mock 'Get-PSKoanLocation' {
+            Join-Path -Path $TestDrive -ChildPath 'PSKoans'
+        }
+
+        Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'Module' } -MockWith {
+            [PSCustomObject]@{
+                Topic        = 'AboutSomething'
+                Path         = Join-Path -Path $TestDrive -ChildPath 'Module\Group\AboutSomething.Koans.ps1'
+                RelativePath = 'Group\AboutSomething.Koans.ps1'
             }
+        }
 
-            Mock Get-PSKoanLocation {
-                Join-Path -Path $TestDrive -ChildPath 'PSKoans'
-            }
-            Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' } -MockWith {
-                [PSCustomObject]@{
-                    Topic        = 'AboutSomething'
-                    Path         = Join-Path -Path $TestDrive -ChildPath 'Module\Group\AboutSomething.Koans.ps1'
-                    RelativePath = 'Group\AboutSomething.Koans.ps1'
+        New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Module\Group') -ItemType Directory
+        New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'PSKoans\Group') -ItemType Directory
+
+        $userFilePath = Get-PSKoanLocation | Join-Path -ChildPath 'Group\AboutSomething.Koans.ps1'
+
+        Set-Content -Path (Get-PSKoan -Scope Module).Path, $userFilePath -Value @'
+            using module PSKoans
+            [Koan(Position = 1)]
+            param ( )
+
+            Describe 'AboutSomething' {
+                It 'existing content' {
+                    __ | Should -Be 1
+                }
+
+                It 'reset content' {
+                    __ | Should -Be 2
+                }
+
+                Context 'first' {
+                    It 'nested reset content' {
+                        __ | Should -Be 3
+                    }
+                }
+
+                Context 'second' {
+                    It 'nested reset content' {
+                        __ | Should -Be 4
+                    }
                 }
             }
-            New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'Module\Group') -ItemType Directory
-            New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'PSKoans\Group') -ItemType Directory
+'@
+    }
 
-            $userFilePath = Get-PSKoanLocation | Join-Path -ChildPath 'Group\AboutSomething.Koans.ps1'
+    Context 'User file exists, It block exists' {
 
-            Set-Content -Path (Get-PSKoan -Scope Module).Path, $userFilePath -Value @'
+        BeforeAll {
+            Mock 'Set-Content'
+            Mock 'Copy-Item'
+        }
+
+        It 'updates an existing user file when -Name is supplied' {
+            Reset-PSKoan -Name 'existing content' @defaultParams
+
+            Should -Invoke 'Set-Content' -Times 1
+            Should -Invoke 'Copy-Item' -Times 0
+        }
+
+        It 'updates an existing user file when -Context is supplied' {
+            Reset-PSKoan -Context 'first' @defaultParams
+
+            Should -Invoke 'Set-Content' -Times 1 -Exactly
+            Should -Invoke 'Copy-Item' -Times 0
+        }
+
+        It 'updates an existing user file when -Name and -Context are supplied' {
+            Reset-PSKoan -Name 'nested reset content' -Context 'first' @defaultParams
+
+            Should -Invoke 'Set-Content' -Times 1 -Exactly
+            Should -Invoke 'Copy-Item' -Times 0
+        }
+
+        It 'copies a koan file from the module when -Name and -Context are not supplied' {
+            Reset-PSKoan @defaultParams
+
+            Should -Invoke 'Set-Content' -Times 0
+            Should -Invoke 'Copy-Item' -Times 1 -Exactly
+        }
+    }
+
+    Context 'User file exists, It block does not exist' {
+
+        It 'writes a non-terminating error when the user file does not include the specified Koan' {
+            Mock 'Get-KoanIt' -ParameterFilter { $Path -match 'PSKoans' } -Module 'PSKoans'
+
+            { Reset-PSKoan -Topic AboutSomething -Name 'existing content' -ErrorAction Stop @defaultParams } |
+                Should -Throw -ErrorId 'PSKoans.UserItNotFound,Reset-PSKoan'
+        }
+    }
+
+    Context 'User file does not exist' {
+
+        BeforeAll {
+            New-Item "$TestDrive/DoesNotExist.Koans.ps1" -ItemType File > $null
+
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'User' } -Verifiable
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'Module' } -Verifiable -MockWith {
+                [PSCustomObject]@{
+                    Topic        = $Topic
+                    Module       = '_powershell'
+                    Position     = 101
+                    Path         = "$TestDrive/DoesNotExist.Koans.ps1"
+                    RelativePath = 'DoesNotExist.Koans.ps1'
+                    PSTypeName   = 'PSKoans.KoanInfo'
+                }
+            }
+
+            Mock 'Update-PSKoan'
+        }
+
+        It 'calls Update-PSKoan when the topic does not exist in the user location' {
+            Reset-PSKoan -Topic DoesNotExist -ErrorAction Stop @defaultParams
+
+            Should -InvokeVerifiable
+            Should -Invoke Update-PSKoan -Times 1 -Exactly
+        }
+    }
+
+    Context 'Module file does not exist' {
+
+        BeforeAll {
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'Module' }
+        }
+
+        It 'throws a terminating error when no topics are found in the module' {
+            { Reset-PSKoan -Topic DoesNotExist @defaultParams } |
+                Should -Throw -ErrorId 'PSKoans.ModuleTopicNotFound,Reset-PSKoan'
+
+            Should -Invoke 'Get-PSKoan' -Times 1 -Exactly
+        }
+    }
+
+    Context 'Practical tests' {
+
+        BeforeEach {
+            Set-Content -Path $userFilePath -Value @'
                 using module PSKoans
                 [Koan(Position = 1)]
                 param ( )
 
                 Describe 'AboutSomething' {
                     It 'existing content' {
-                        __ | Should -Be 1
+                        1 | Should -Be 1
                     }
 
                     It 'reset content' {
-                        __ | Should -Be 2
+                        1 | Should -Be 2
                     }
 
                     Context 'first' {
                         It 'nested reset content' {
-                            __ | Should -Be 3
+                            3 | Should -Be 3
                         }
                     }
 
                     Context 'second' {
                         It 'nested reset content' {
-                            __ | Should -Be 4
+                            4 | Should -Be 4
                         }
                     }
                 }
 '@
         }
 
-        Context 'User file exists, It block exists' {
-            BeforeAll {
-                Mock Set-Content
-                Mock Copy-Item
-            }
-
-            It 'When Name is supplied, updates an existing user file' {
-                Reset-PSKoan -Name 'existing content' @defaultParams
-
-                Assert-MockCalled Set-Content -Times 1 -Scope It
-                Assert-MockCalled Copy-Item -Times 0 -Scope It
-            }
-
-            It 'When Context is supplied, updates an existing user file' {
-                Reset-PSKoan -Context 'first' @defaultParams
-
-                Assert-MockCalled Set-Content -Times 1 -Exactly -Scope It
-                Assert-MockCalled Copy-Item -Times 0 -Scope It
-            }
-
-            It 'When Name and Context are supplied, updates an existing user file' {
-                Reset-PSKoan -Name 'nested reset content' -Context 'first' @defaultParams
-
-                Assert-MockCalled Set-Content -Times 1 -Exactly -Scope It
-                Assert-MockCalled Copy-Item -Times 0 -Scope It
-            }
-
-            It 'When Name and Context are not supplied, copies a koan file from the module' {
-                Reset-PSKoan @defaultParams
-
-                Assert-MockCalled Set-Content -Times 0 -Scope It
-                Assert-MockCalled Copy-Item -Times 1 -Exactly -Scope It
-            }
+        It 'should reset all koans in a file when Name is not specified' {
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 1'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 4'
         }
 
-        Context 'User file exists, It block does not exist' {
-            BeforeAll {
-                Mock Get-KoanIt -ParameterFilter { $Path -match 'PSKoans' }
-            }
+        It 'should reset the state of a single koan without affecting others when Name is specified' {
+            Reset-PSKoan -Topic AboutSomething -Name 'reset content' @defaultParams
 
-            It 'When the user file does not include the specified Koan, writes a non-terminating error' {
-                { Reset-PSKoan -Topic AboutSomething -Name 'existing content' -ErrorAction Stop @defaultParams } | Should -Throw -ErrorId PSKoans.UserItNotFound
-            }
+            $userFilePath | Should -FileContentMatch '1 | Should -Be 1'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
         }
 
-        Context 'User file does not exist' {
-            BeforeAll {
-                New-Item "$TestDrive/DoesNotExist.Koans.ps1" -ItemType File > $null
-                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'User' }
-                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' } {
-                    [PSCustomObject]@{
-                        Topic        = $Topic
-                        Module       = '_powershell'
-                        Position     = 101
-                        Path         = "$TestDrive/DoesNotExist.Koans.ps1"
-                        RelativePath = 'DoesNotExist.Koans.ps1'
-                        PSTypeName   = 'PSKoans.KoanInfo'
-                    }
-                }
-                Mock Update-PSKoan
-            }
+        It 'supports context based searching' {
+            Reset-PSKoan -Topic AboutSomething -Name "nested reset content" -Context 'first' @defaultParams
 
-            It 'When the topic does not exist in the user location, call Update-PSKoan' {
-                Reset-PSKoan -Topic DoesNotExist -ErrorAction Stop @defaultParams
-
-                Assert-MockCalled Update-PSKoan -Times 1
-            }
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
+            $userFilePath | Should -FileContentMatch '4 | Should -Be 4'
         }
 
-        Context 'Module file does not exist' {
-            BeforeAll {
-                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' }
-            }
+        It 'allows koans of a given name to be reset across all contexts' {
+            Reset-PSKoan -Topic AboutSomething -Name "nested reset content" @defaultParams
 
-            It 'When no topics are found in the module, throw a terminating error' {
-                { Reset-PSKoan -Topic DoesNotExist @defaultParams } | Should -Throw -ErrorId PSKoans.ModuleTopicNotFound
-            }
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 4'
         }
 
-        Context 'Practical tests' {
-            BeforeEach {
-                Set-Content -Path $userFilePath -Value @'
-                    using module PSKoans
-                    [Koan(Position = 1)]
-                    param ( )
+        It 'supports wildcard patterns when matching name' {
+            Reset-PSKoan -Topic AboutSomething -Name "*content" @defaultParams
 
-                    Describe 'AboutSomething' {
-                        It 'existing content' {
-                            1 | Should -Be 1
-                        }
-
-                        It 'reset content' {
-                            1 | Should -Be 2
-                        }
-
-                        Context 'first' {
-                            It 'nested reset content' {
-                                3 | Should -Be 3
-                            }
-                        }
-
-                        Context 'second' {
-                            It 'nested reset content' {
-                                4 | Should -Be 4
-                            }
-                        }
-                    }
-'@
-            }
-
-            It 'should reset all koans in a file when Name is not specified' {
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 1'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 4'
-            }
-
-            It 'should reset the state of a single koan without affecting others when Name is specified' {
-                Reset-PSKoan -Topic AboutSomething -Name 'reset content' @defaultParams
-
-                $userFilePath | Should -FileContentMatch '1 | Should -Be 1'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
-            }
-
-            It 'supports context based searching' {
-                Reset-PSKoan -Topic AboutSomething -Name "nested reset content" -Context 'first' @defaultParams
-
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
-                $userFilePath | Should -FileContentMatch '4 | Should -Be 4'
-            }
-
-            It 'allows koans of a given name to be reset across all contexts' {
-                Reset-PSKoan -Topic AboutSomething -Name "nested reset content" @defaultParams
-
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 3'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 4'
-            }
-
-            It 'supports wildcard patterns when matching name' {
-                Reset-PSKoan -Topic AboutSomething -Name "*content" @defaultParams
-
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 1'
-                $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
-            }
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 1'
+            $userFilePath | Should -FileContentMatch '__ | Should -Be 2'
         }
     }
 }

--- a/Tests/Functions/Public/Set-PSKoanLocation.Tests.ps1
+++ b/Tests/Functions/Public/Set-PSKoanLocation.Tests.ps1
@@ -1,8 +1,9 @@
 ﻿#Requires -Modules PSKoans
 
 Describe 'Set-PSKoanLocation' {
+
     BeforeAll {
-        Mock Set-PSKoanSetting -ParameterFilter { $Name -eq 'KoanLocation' } -ModuleName PSKoans
+        Mock 'Set-PSKoanSetting' -ParameterFilter { $Name -eq 'KoanLocation' }
     }
 
     It 'outputs no data by default' {
@@ -10,7 +11,7 @@ Describe 'Set-PSKoanLocation' {
     }
 
     It 'sets the KoanLocation setting' {
-        Assert-MockCalled Set-PSKoanSetting -ModuleName PSKoans
+        Should -Invoke 'Set-PSKoanSetting' -Scope Describe
     }
 
     It 'returns the input -Path value back to the pipeline with -PassThru' {

--- a/Tests/Functions/Public/Set-PSKoanSetting.Tests.ps1
+++ b/Tests/Functions/Public/Set-PSKoanSetting.Tests.ps1
@@ -1,6 +1,7 @@
 #Requires -Modules PSKoans
 
 Describe 'Set-PSKoanSetting' {
+
     BeforeAll {
         InModuleScope 'PSKoans' {
             $script:OldConfigPath = $script:ConfigPath
@@ -16,6 +17,7 @@ Describe 'Set-PSKoanSetting' {
     Context 'Settings file Exists' {
 
         Describe 'Setting values with -Name and -Value' {
+
             BeforeAll {
                 $NewConfigPath = InModuleScope 'PSKoans' {
                     ($script:ConfigPath = "$TestDrive/config.json")
@@ -25,28 +27,23 @@ Describe 'Set-PSKoanSetting' {
                     New-Item -ItemType File -Path "$TestDrive/config.json"
                 }
 
-                $Settings = [PSCustomObject]@{
+                [PSCustomObject]@{
                     LibraryFolder = "$TestDrive/PSKoans"
                     Editor        = 'code'
-                }
-                $Settings |
+                } |
                     ConvertTo-Json |
                     Set-Content -Path $NewConfigPath
-
-                $TestCases = @(
-                    @{ Name = 'TestSetting1'; Value = 'TestValue1' }
-                    @{ Name = 'LibraryFolder'; Value = "$TestDrive/AltLocation/PSKoans" }
-                    @{ Name = 'Editor'; Value = 'code-insiders' }
-                )
             }
 
             AfterAll {
                 Remove-Item -Path $NewConfigPath -Force
             }
 
-            It 'should add a new setting: <Name> = <Value>' -TestCases $TestCases {
-                param($Name, $Value)
-
+            It 'should add a new setting: <Name> = <Value>' -TestCases @(
+                @{ Name = 'TestSetting1'; Value = 'TestValue1' }
+                @{ Name = 'LibraryFolder'; Value = "TestDrive:/PSKoans" }
+                @{ Name = 'Editor'; Value = 'code-insiders' }
+            ) {
                 Set-PSKoanSetting -Name $Name -Value $Value
 
                 Get-PSKoanSetting -Name $Name | Should -BeExactly $Value
@@ -58,6 +55,7 @@ Describe 'Set-PSKoanSetting' {
         }
 
         Context 'Setting values with -Settings Hashtable' {
+
             BeforeAll {
                 $NewConfigPath = InModuleScope 'PSKoans' {
                     ($script:ConfigPath = "$TestDrive/config.json")
@@ -67,11 +65,10 @@ Describe 'Set-PSKoanSetting' {
                     New-Item -ItemType File -Path "$TestDrive/config.json"
                 }
 
-                $Settings = [PSCustomObject]@{
+                [PSCustomObject]@{
                     LibraryFolder = "$TestDrive/PSKoans"
                     Editor        = 'code'
-                }
-                $Settings |
+                } |
                     ConvertTo-Json |
                     Set-Content -Path $NewConfigPath
             }
@@ -85,6 +82,7 @@ Describe 'Set-PSKoanSetting' {
                     TestSetting2  = "TestValue2"
                     LibraryFolder = "$TestDrive/PSKoans"
                 }
+
                 Set-PSKoanSetting -Settings $NewSettings
                 $Settings = Get-PSKoanSetting
 
@@ -98,17 +96,13 @@ Describe 'Set-PSKoanSetting' {
     Context 'Settings file does not exist' {
 
         Describe 'Setting values with -Name and -Value' {
+
             BeforeAll {
                 $NewConfigPath = InModuleScope 'PSKoans' {
                     ($script:ConfigPath = "$TestDrive/config.json")
                 }
 
                 $DefaultSettings = InModuleScope 'PSKoans' { $script:DefaultSettings }
-                $TestCases = @(
-                    @{ Name = 'TestSetting1' ; Value = 'TestValue1' }
-                    @{ Name = 'Editor'; Value = 'TestEditor' }
-                    @{ Name = 'LibraryFolder'; Value = "$TestDrive/TestFolder" }
-                )
             }
 
             BeforeEach {
@@ -117,9 +111,11 @@ Describe 'Set-PSKoanSetting' {
                 }
             }
 
-            It 'correctly adds the setting: <Name> = <Value>' -TestCases $TestCases {
-                param($Name, $Value)
-
+            It 'correctly adds the setting: <Name> = <Value>' -TestCases @(
+                @{ Name = 'TestSetting1' ; Value = 'TestValue1' }
+                @{ Name = 'Editor'; Value = 'TestEditor' }
+                @{ Name = 'LibraryFolder'; Value = "$env:TEMP/TestFolder" }
+            ) {
                 $NewConfigPath | Should -Not -Exist
                 Set-PSKoanSetting -Name $Name -Value $Value
                 $NewConfigPath | Should -Exist
@@ -135,28 +131,25 @@ Describe 'Set-PSKoanSetting' {
         }
 
         Context 'Setting values with -Settings Hashtable' {
+
             BeforeAll {
                 $NewConfigPath = InModuleScope 'PSKoans' {
                     ($script:ConfigPath = "$TestDrive/config.json")
                 }
 
                 $DefaultSettings = InModuleScope 'PSKoans' { $script:DefaultSettings }
-                $TestCases = @(
-                    @{ Settings = @{ TestSetting1 = 'TestValue1'; Editor = 'TestEditor' } }
-                    @{ Settings = @{ LibraryFolder = "$TestDrive/TestFolder"; TestSetting2 = 'TestValue2' } }
-                )
             }
 
             BeforeEach {
                 if (Test-Path -Path $NewConfigPath) {
                     Remove-Item -Path $NewConfigPath
                 }
-
             }
 
-            It 'adds and replaces values: <Settings>' -TestCases $TestCases {
-                param($Settings)
-
+            It 'adds and replaces values: <Settings>' -TestCases @(
+                @{ Settings = @{ TestSetting1 = 'TestValue1'; Editor = 'TestEditor' } }
+                @{ Settings = @{ LibraryFolder = "$TestDrive/TestFolder"; TestSetting2 = 'TestValue2' } }
+            ) {
                 $NewConfigPath | Should -Not -Exist
                 Set-PSKoanSetting -Settings $Settings
                 $NewConfigPath | Should -Exist

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -1,15 +1,11 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
-
-    Import-Module $moduleBase -Force
-}
-#endregion
+#Requires -Modules PSKoans
 
 Describe 'Show-Karma' {
+
     BeforeAll {
-        $StartingLocation = Get-PSKoanLocation
-        Set-PSKoanLocation -Path "$TestDrive/Koans"
+        Mock 'Get-PSKoanLocation' {
+            "$TestDrive/Koans"
+        }
 
         $EditorSetting = Get-PSKoanSetting -Name Editor
 
@@ -17,355 +13,367 @@ Describe 'Show-Karma' {
     }
 
     AfterAll {
-        Set-PSKoanLocation -Path $StartingLocation
         Set-PSKoanSetting -Name Editor -Value $EditorSetting
     }
 
-    InModuleScope 'PSKoans' {
+    Context 'Default Behaviour' {
 
-        Context 'Default Behaviour' {
-            BeforeAll {
-                Mock Out-Host { }
-                Mock Get-Karma -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{
-                        PSTypeName   = 'PSKoans.Result'
-                        Meditation   = 'TestMeditation'
-                        KoansPassed  = 0
-                        TotalKoans   = 400
-                        Describe     = 'TestDescribe'
-                        Expectation  = 'ExpectedTest'
-                        It           = 'TestIt'
-                        CurrentTopic = [PSCustomObject]@{
-                            Name        = 'TestTopic"'
-                            Completed   = 0
-                            Total       = 4
-                            CurrentLine = 1
-                        }
-                    }
-                }
-            }
-
-            It 'should not produce output' {
-                Show-Karma | Should -BeNullOrEmpty
-            }
-
-            It 'should write the formatted output to host' {
-                Assert-MockCalled Out-Host
-            }
-
-            It 'should call Get-Karma to examine the koans' {
-                Assert-MockCalled Get-Karma
-            }
-        }
-
-        Context 'With All Koans Completed' {
-            BeforeAll {
-                Mock Out-Host { }
-                Mock Get-Karma -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{
-                        PSTypeName     = 'PSKoans.CompleteResult'
-                        KoansPassed    = 10
-                        TotalKoans     = 10
-                        RequestedTopci = $null
-                        Complete       = $true
-                    }
-                }
-            }
-
-            It 'should not throw errors' {
-                { Show-Karma } | Should -Not -Throw
-            }
-        }
-
-        Context 'With -ClearScreen Switch' {
-            BeforeAll {
-                Mock Clear-Host { }
-                Mock Out-Host { }
-                Mock Get-Karma -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{
-                        PSTypeName   = 'PSKoans.Result'
-                        Meditation   = 'TestMeditation'
-                        KoansPassed  = 0
-                        TotalKoans   = 400
-                        Describe     = 'TestDescribe'
-                        Expectation  = 'ExpectedTest'
-                        It           = 'TestIt'
-                        CurrentTopic = [PSCustomObject]@{
-                            Name        = 'TestTopic"'
-                            Completed   = 0
-                            Total       = 4
-                            CurrentLine = 1
-                        }
-                    }
-                }
-            }
-
-            It 'should not produce output' {
-                Show-Karma -ClearScreen | Should -Be $null
-            }
-
-            It 'should clear the screen' {
-                Assert-MockCalled Clear-Host -Times 1
-            }
-
-            It 'should display the rendered output' {
-                Assert-MockCalled Out-Host
-            }
-
-            It 'should Invoke-Pester on each of the koans' {
-                Assert-MockCalled Get-Karma
-            }
-        }
-
-        Context 'With Nonexistent Koans Folder / No Koans Found' {
-            BeforeAll {
-                Mock Out-Host { }
-                Mock Get-PSKoan -ModuleName 'PSKoans' { }
-                Mock Update-PSKoan -ModuleName 'PSKoans' { throw 'Prevent recursion' }
-                Mock Write-Warning
-                Mock Test-Path { $false }
-                Mock Invoke-Item
-                Mock New-Item
-            }
-
-            BeforeEach {
-                $script:CurrentTopic = $null
-            }
-
-            It 'should attempt to populate koans and then recurse to reassess' {
-                { Show-Karma } | Should -Throw -ExpectedMessage 'Prevent recursion'
-            }
-
-            It 'should display a warning before initiating a reset' {
-                Assert-MockCalled Write-Warning
-            }
-
-            It 'throws an error if a Topic is specified that matches nothing' {
-                { Show-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound'
-            }
-
-            It 'should create PSKoans directory with -Library' {
-                { Show-Karma -Library } | Should -Throw -ExpectedMessage 'Prevent recursion'
-
-                Assert-MockCalled Test-Path -Times 1
-                Assert-MockCalled Update-PSKoan -Times 1
-                Assert-MockCalled New-Item -Times 1
-            }
-
-            It 'should create PSKoans directory with -Contemplate' {
-                { Show-Karma -Contemplate } | Should -Throw -ExpectedMessage 'Prevent recursion'
-
-                Assert-MockCalled Test-Path -Times 1
-                Assert-MockCalled Update-PSKoan -Times 1
-                Assert-MockCalled New-Item -Times 1
-            }
-        }
-
-        Context 'With -ListTopics Parameter' {
-            BeforeAll {
-                Mock Get-PSKoan
-            }
-
-            It 'should list all the koan topics' {
-                Show-Karma -ListTopics
-                Assert-MockCalled Get-PSKoan
-            }
-        }
-
-        Context 'With -Topic Parameter' {
-            BeforeAll {
-                Mock Out-Host { }
-                Mock Get-Karma -MockWith {
-                    [PSCustomObject]@{
-                        PSTypeName     = 'PSKoans.Result'
-                        Meditation     = 'TestMeditation'
-                        KoansPassed    = 0
-                        TotalKoans     = 400
-                        Describe       = 'TestDescribe'
-                        Expectation    = 'ExpectedTest'
-                        It             = 'TestIt'
-                        CurrentTopic   = [PSCustomObject]@{
-                            Name        = 'TestTopic"'
-                            Completed   = 0
-                            Total       = 4
-                            CurrentLine = 1
-                        }
-                        RequestedTopic = $Topic
-                    }
-                } -ParameterFilter { $Topic }
-            }
-
-            It 'should call Get-Karma on the selected topic' {
-                Show-Karma -Topic TestTopic
-                Assert-MockCalled Get-Karma -ParameterFilter { $Topic -eq "TestTopic" }
-            }
-        }
-
-        Context 'With All Koans in a Single Topic Completed' {
-            BeforeAll {
-                Mock Format-Custom { $InputObject.Complete }
-                Mock Out-Host { }
-                Mock Get-Karma -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{
-                        PSTypeName     = 'PSKoans.CompleteResult'
-                        KoansPassed    = 10
-                        TotalKoans     = 10
-                        RequestedTopic = 'TestTopic'
-                        Complete       = $true
-                    }
-                }
-            }
-
-            It 'should not throw errors' {
-                { Show-Karma } | Should -Not -Throw
-            }
-        }
-
-        Context 'With -Contemplate Switch' {
-            BeforeAll {
-                $TestFile = New-TemporaryFile
-
-                Mock Invoke-Item { $Path }
-                Mock Get-Command { $true } -ParameterFilter { $Name -ne "missing_editor" }
-                Mock Get-Command { $false } -ParameterFilter { $Name -eq "missing_editor" }
-                Mock Start-Process {
-                    @{ Editor = $FilePath; Arguments = $ArgumentList; NoNewWindow = $NoNewWindow }
-                }
-                Mock Get-Karma -ModuleName 'PSKoans' {
-                    $script:CurrentTopic = @{
-                        Name        = 'TestTopic'
+        BeforeAll {
+            Mock 'Out-Host'
+            Mock 'Get-Karma' {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSKoans.Result'
+                    Meditation   = 'TestMeditation'
+                    KoansPassed  = 0
+                    TotalKoans   = 400
+                    Describe     = 'TestDescribe'
+                    Expectation  = 'ExpectedTest'
+                    It           = 'TestIt'
+                    CurrentTopic = [PSCustomObject]@{
+                        Name        = 'TestTopic"'
                         Completed   = 0
                         Total       = 4
                         CurrentLine = 1
                     }
-
-                    [PSCustomObject]@{
-                        PSTypeName   = 'PSKoans.Result'
-                        Meditation   = 'TestMeditation'
-                        KoansPassed  = 0
-                        TotalKoans   = 400
-                        Describe     = 'TestDescribe'
-                        Expectation  = 'ExpectedTest'
-                        It           = 'TestIt'
-                        CurrentTopic = [PSCustomObject]$script:CurrentTopic
-                    }
                 }
-                Mock Get-PSKoan -ModuleName 'PSKoans' {
-                    [PSCustomObject]@{ Path = $TestFile.FullName }
-                } -ParameterFilter { $Topic -eq 'TestTopic' }
-            }
-
-            AfterAll {
-                $TestFile | Remove-Item
-            }
-
-            It 'invokes VS Code with "code" set as Editor with proper arguments' {
-                Set-PSKoanSetting -Name Editor -Value 'code'
-                $Result = Show-Karma -Contemplate
-
-                $Result.Editor | Should -BeExactly 'code'
-                $Result.Arguments[0] | Should -BeExactly '--goto'
-                $Result.Arguments[1] | Should -MatchExactly '"[^"]+":\d+'
-                $Result.Arguments[2] | Should -BeExactly '--reuse-window'
-                $Result.NoNewWindow | Should -BeTrue
-
-                # Resolve-Path doesn't like embedded quotes
-                $Path = ($Result.Arguments[1] -split '(?<="):')[0] -replace '"'
-                $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
-
-                Assert-MockCalled Get-Command -Times 1
-                Assert-MockCalled Start-Process -Times 1
-
-                $script:CurrentTopic | Should -BeNullOrEmpty
-            }
-
-            It 'opens the specified -Topic in the selected editor' {
-                Set-PSKoanSetting -Name Editor -Value 'code'
-                $Result = Show-Karma -Contemplate -Topic TestTopic
-
-                $Result.Arguments[1] | Should -MatchExactly ([regex]::Escape($TestFile.FullName))
-
-                Assert-MockCalled Get-Command -Times 1
-                Assert-MockCalled Start-Process -Times 1
-
-                $script:CurrentTopic | Should -BeNullOrEmpty
-            }
-
-            It 'invokes the set editor with unknown editor chosen' {
-                Set-PSKoanSetting -Name Editor -Value 'vim'
-
-                $Result = Show-Karma -Contemplate
-                $Result.Editor | Should -BeExactly 'vim'
-                $Result.Arguments | Should -MatchExactly '"[^"]+"'
-
-                # Resolve-Path doesn't like embedded quotes
-                $Path = $Result.Arguments -replace '"'
-                $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
-
-                Assert-MockCalled Get-Command -Times 1
-                Assert-MockCalled Start-Process -Times 1
-
-                $script:CurrentTopic | Should -BeNullOrEmpty
-            }
-
-            It 'opens the file directly when selected editor is unavailable' {
-                Set-PSKoanSetting -Name Editor -Value "missing_editor"
-
-                Show-Karma -Contemplate | Should -BeExactly $TestFile.FullName
-
-                Assert-MockCalled Get-Command -Times 1 -ParameterFilter { $Name -eq "missing_editor" }
-                Assert-MockCalled Invoke-Item -Times 1
-
-                $script:CurrentTopic | Should -BeNullOrEmpty
             }
         }
 
-        Context 'With -Library Switch' {
-            BeforeAll {
-                Mock Get-Command { $true } -ParameterFilter { $Name -ne "missing_editor" }
-                Mock Get-Command { $false } -ParameterFilter { $Name -eq "missing_editor" }
-                Mock Start-Process {
-                    @{ Editor = $FilePath; Arguments = $ArgumentList }
+        It 'should not produce output' {
+            Show-Karma | Should -BeNullOrEmpty
+        }
+
+        It 'should write the formatted output to host' {
+            Should -Invoke 'Out-Host' -Scope Context
+        }
+
+        It 'should call Get-Karma to examine the koans' {
+            Should -Invoke 'Get-Karma' -Scope Context
+        }
+    }
+
+    Context 'With All Koans Completed' {
+
+        BeforeAll {
+            Mock 'Out-Host' -Verifiable
+            Mock 'Get-Karma' -Verifiable {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSKoans.CompleteResult'
+                    KoansPassed    = 10
+                    TotalKoans     = 10
+                    RequestedTopci = $null
+                    Complete       = $true
                 }
-                Mock Invoke-Item { $Path }
+            }
+        }
+
+        It 'should not throw errors' {
+            { Show-Karma } | Should -Not -Throw
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context 'With -ClearScreen Switch' {
+
+        BeforeAll {
+            Mock 'Clear-Host'
+            Mock 'Out-Host'
+            Mock 'Get-Karma' {
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSKoans.Result'
+                    Meditation   = 'TestMeditation'
+                    KoansPassed  = 0
+                    TotalKoans   = 400
+                    Describe     = 'TestDescribe'
+                    Expectation  = 'ExpectedTest'
+                    It           = 'TestIt'
+                    CurrentTopic = [PSCustomObject]@{
+                        Name        = 'TestTopic"'
+                        Completed   = 0
+                        Total       = 4
+                        CurrentLine = 1
+                    }
+                }
+            }
+        }
+
+        It 'should not produce output' {
+            Show-Karma -ClearScreen | Should -Be $null
+        }
+
+        It 'should clear the screen' {
+            Should -Invoke 'Clear-Host' -Scope Context -Times 1 -Exactly
+        }
+
+        It 'should display the rendered output' {
+            Should -Invoke 'Out-Host' -Scope Context
+        }
+
+        It 'should use Get-Karma to retrieve koan results' {
+            Should -Invoke 'Get-Karma' -Scope Context -Times 1 -Exactly
+        }
+    }
+
+    Context 'With Nonexistent Koans Folder / No Koans Found' {
+
+        BeforeAll {
+            Mock 'Write-Host'
+            Mock 'Get-PSKoan'
+            Mock 'Update-PSKoan' { throw 'Prevent recursion' }
+            Mock 'Write-Warning'
+            Mock 'Test-Path' { $false }
+            Mock 'Invoke-Item'
+            Mock 'Measure-Koan' -ModuleName 'PSKoans'
+        }
+
+        BeforeEach {
+            InModuleScope 'PSKoans' { $script:CurrentTopic = $null }
+        }
+
+        It 'should attempt to populate koans and then recurse to reassess' {
+            { Show-Karma } | Should -Throw -ExpectedMessage 'Prevent recursion'
+        }
+
+        It 'should display a warning before initiating a reset' {
+            Should -Invoke 'Write-Warning' -Scope Context -Times 1 -Exactly
+        }
+
+        It 'throws an error if a Topic is specified that matches nothing' {
+            { Show-Karma -Topic 'AboutAbsolutelyNothing' } | Should -Throw -ErrorId 'PSKoans.TopicNotFound,Show-Karma'
+        }
+
+        It 'should create PSKoans directory with -Library' {
+            { Show-Karma -Library } | Should -Throw -ExpectedMessage 'Prevent recursion'
+
+            Should -Invoke 'Test-Path'
+            Should -Invoke 'Update-PSKoan' -Times 1 -Exactly
+        }
+
+        It 'should call Get-PSKoan to retrieve the correct file -Contemplate' {
+            { Show-Karma -Contemplate } | Should -Throw -ExpectedMessage 'Prevent recursion'
+
+            Should -Invoke 'Get-PSKoan' -Times 1 -Exactly
+            Should -Invoke 'Update-PSKoan' -Times 1 -Exactly
+        }
+    }
+
+    Context 'With -ListTopics Parameter' {
+
+        BeforeAll {
+            Mock 'Get-PSKoan'
+        }
+
+        It 'should list all the koan topics' {
+            Show-Karma -ListTopics
+            Should -Invoke 'Get-PSKoan' -Times 1 -Exactly
+        }
+    }
+
+    Context 'With -Topic Parameter' {
+
+        BeforeAll {
+            Mock 'Out-Host' -Verifiable
+            Mock 'Get-Karma' -ParameterFilter { $Topic -eq 'TestTopic' } -Verifiable -MockWith {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSKoans.Result'
+                    Meditation     = 'TestMeditation'
+                    KoansPassed    = 0
+                    TotalKoans     = 400
+                    Describe       = 'TestDescribe'
+                    Expectation    = 'ExpectedTest'
+                    It             = 'TestIt'
+                    CurrentTopic   = [PSCustomObject]@{
+                        Name        = 'TestTopic"'
+                        Completed   = 0
+                        Total       = 4
+                        CurrentLine = 1
+                    }
+                    RequestedTopic = $Topic
+                }
+            }
+        }
+
+        It 'should call Get-Karma on the selected topic' {
+            Show-Karma -Topic TestTopic
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context 'With All Koans in a Single Topic Completed' {
+
+        BeforeAll {
+            Mock 'Format-Custom' -Verifiable { $null }
+            Mock 'Out-Host' -Verifiable
+            Mock 'Get-Karma' -Verifiable {
+                [PSCustomObject]@{
+                    PSTypeName     = 'PSKoans.CompleteResult'
+                    KoansPassed    = 10
+                    TotalKoans     = 10
+                    RequestedTopic = 'TestTopic'
+                    Complete       = $true
+                }
+            }
+        }
+
+        It 'should not throw errors' {
+            { Show-Karma } | Should -Not -Throw
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context 'With -Contemplate Switch' {
+
+        BeforeAll {
+            $TestFile = New-TemporaryFile
+
+            Mock 'Invoke-Item' { $Path }
+            Mock 'Get-Command' { $true } -ParameterFilter { $Name -ne "missing_editor" }
+            Mock 'Get-Command' { $false } -ParameterFilter { $Name -eq "missing_editor" }
+            Mock 'Start-Process' {
+                @{ Editor = $FilePath; Arguments = $ArgumentList; NoNewWindow = $NoNewWindow }
             }
 
-            It 'invokes VS Code with "code" set as Editor with proper arguments' {
-                Set-PSKoanSetting -Name Editor -Value 'code'
-                $Result = Show-Karma -Library
+            Mock 'Get-Karma' {
+                $currentTopic = @{
+                    Name        = 'TestTopic'
+                    Completed   = 0
+                    Total       = 4
+                    CurrentLine = 1
+                }
 
-                $Result.Editor | Should -BeExactly 'code'
+                [PSCustomObject]@{
+                    PSTypeName   = 'PSKoans.Result'
+                    Meditation   = 'TestMeditation'
+                    KoansPassed  = 0
+                    TotalKoans   = 400
+                    Describe     = 'TestDescribe'
+                    Expectation  = 'ExpectedTest'
+                    It           = 'TestIt'
+                    CurrentTopic = [PSCustomObject]$currentTopic
+                }
 
-                # Resolve-Path doesn't like embedded quotes
-                $Path = $Result.Arguments -replace '"'
-                $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
-
-                Assert-MockCalled Get-Command -Times 1
-                Assert-MockCalled Start-Process -Times 1
+                InModuleScope 'PSKoans' -Parameters @{ Topic = $currentTopic } {
+                    param($Topic)
+                    $script:CurrentTopic = $Topic
+                }
             }
 
-            It 'invokes the set editor with unknown editor chosen' {
-                Set-PSKoanSetting -Name Editor -Value 'vim'
-
-                $Result = Show-Karma -Library
-                $Result.Editor | Should -BeExactly 'vim'
-
-                # Resolve-Path doesn't like embedded quotes
-                $Path = $Result.Arguments -replace '"'
-                $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
-
-                Assert-MockCalled Get-Command -Times 1
-                Assert-MockCalled Start-Process -Times 1
+            Mock 'Get-PSKoan' -ParameterFilter { $Topic -eq 'TestTopic' -and $Scope -eq 'User' } {
+                [PSCustomObject]@{ Path = $TestFile.FullName }
             }
+        }
 
-            It 'opens the file directly when selected editor is unavailable' {
-                Set-PSKoanSetting -Name Editor -Value "missing_editor"
+        AfterAll {
+            $TestFile | Remove-Item
+        }
 
-                Show-Karma -Library | Should -BeExactly (Get-PSKoanLocation)
+        It 'invokes VS Code with "code" set as Editor with proper arguments' {
+            Set-PSKoanSetting -Name Editor -Value 'code'
+            $Result = Show-Karma -Contemplate
 
-                Assert-MockCalled Get-Command -Times 1 -ParameterFilter { $Name -eq "missing_editor" }
-                Assert-MockCalled Invoke-Item -Times 1
+            $Result.Editor | Should -BeExactly 'code'
+            $Result.Arguments[0] | Should -BeExactly '--goto'
+            $Result.Arguments[1] | Should -MatchExactly '"[^"]+":\d+'
+            $Result.Arguments[2] | Should -BeExactly '--reuse-window'
+            $Result.NoNewWindow | Should -BeTrue
+
+            # Resolve-Path doesn't like embedded quotes
+            $Path = ($Result.Arguments[1] -split '(?<="):')[0] -replace '"'
+            $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly
+            Should -Invoke 'Start-Process' -Times 1 -Exactly
+
+            InModuleScope 'PSKoans' { $script:CurrentTopic } | Should -BeNullOrEmpty
+        }
+
+        It 'opens the specified -Topic in the selected editor' {
+            Set-PSKoanSetting -Name Editor -Value 'code'
+
+            $Result = Show-Karma -Contemplate -Topic TestTopic
+            $Result.Arguments[1] | Should -MatchExactly ([regex]::Escape($TestFile.FullName))
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly
+            Should -Invoke 'Start-Process' -Times 1 -Exactly
+
+            InModuleScope 'PSKoans' { $script:CurrentTopic } | Should -BeNullOrEmpty
+        }
+
+        It 'invokes the set editor with unknown editor chosen' {
+            Set-PSKoanSetting -Name Editor -Value 'vim'
+
+            $Result = Show-Karma -Contemplate
+            $Result.Editor | Should -BeExactly 'vim'
+            $Result.Arguments | Should -MatchExactly '"[^"]+"'
+
+            # Resolve-Path doesn't like embedded quotes
+            $Path = $Result.Arguments -replace '"'
+            $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly
+            Should -Invoke 'Start-Process' -Times 1 -Exactly
+
+            InModuleScope 'PSKoans' { $script:CurrentTopic } | Should -BeNullOrEmpty
+        }
+
+        It 'opens the file directly when selected editor is unavailable' {
+            Set-PSKoanSetting -name Editor -Value "missing_editor"
+
+            Show-Karma -Contemplate | Should -BeExactly $TestFile.FullName
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly -ParameterFilter { $Name -eq "missing_editor" }
+            Should -Invoke 'Invoke-Item' -Times 1 -Exactly
+
+            InModuleScope 'PSKoans' { $script:CurrentTopic } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'With -Library Switch' {
+
+        BeforeAll {
+            Mock 'Get-Command' { $true } -ParameterFilter { $Name -ne "missing_editor" }
+            Mock 'Get-Command' { $false } -ParameterFilter { $Name -eq "missing_editor" }
+            Mock 'Start-Process' {
+                @{ Editor = $FilePath; Arguments = $ArgumentList }
             }
+            Mock 'Invoke-Item' { $Path }
+        }
+
+        It 'invokes VS Code with "code" set as Editor with proper arguments' {
+            Set-PSKoanSetting -Name Editor -Value 'code'
+
+            $Result = Show-Karma -Library
+            $Result.Editor | Should -BeExactly 'code'
+
+            # Resolve-Path doesn't like embedded quotes
+            $Path = $Result.Arguments -replace '"'
+            $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly
+            Should -Invoke 'Start-Process' -Times 1 -Exactly
+        }
+
+        It 'invokes the set editor with unknown editor chosen' {
+            Set-PSKoanSetting -Name Editor -Value 'vim'
+
+            $Result = Show-Karma -Library
+            $Result.Editor | Should -BeExactly 'vim'
+
+            # Resolve-Path doesn't like embedded quotes
+            $Path = $Result.Arguments -replace '"'
+            $Path | Should -BeExactly (Resolve-Path -Path $Path).Path
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly
+            Should -Invoke 'Start-Process' -Times 1 -Exactly
+        }
+
+        It 'opens the file directly when selected editor is unavailable' {
+            Set-PSKoanSetting -name Editor -Value "missing_editor"
+
+            Show-Karma -Library | Should -BeExactly (Get-PSKoanLocation)
+
+            Should -Invoke 'Get-Command' -Times 1 -Exactly -ParameterFilter { $Name -eq "missing_editor" }
+            Should -Invoke 'Invoke-Item' -Times 1 -Exactly
         }
     }
 }

--- a/Tests/Functions/Public/Update-PSKoan.Tests.ps1
+++ b/Tests/Functions/Public/Update-PSKoan.Tests.ps1
@@ -1,115 +1,109 @@
-#region Header
-if (-not (Get-Module PSKoans)) {
-    $moduleBase = Join-Path -Path $psscriptroot.Substring(0, $psscriptroot.IndexOf('\Tests')) -ChildPath 'PSKoans'
+#Requires -Modules PSKoans
 
-    Import-Module $moduleBase -Force
-}
-#endregion
+Describe 'Update-PSKoan' {
 
-InModuleScope 'PSKoans' {
-    Describe 'Update-PSKoan' {
+    Context 'Mocked Commands' {
+
         BeforeAll {
-            Mock Get-PSKoanLocation {
+            Mock 'Remove-Item'
+            Mock 'Copy-Item'
+            Mock 'New-Item'
+            Mock 'Move-Item'
+            Mock 'Update-PSKoanFile' -ModuleName 'PSKoans'
+
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'Module' } -MockWith {
+                [PSCustomObject]@{
+                    Topic = 'Missing'
+                    Path  = 'Module\Group\AboutSomethingMissing.Koans.ps1'
+                }
+                [PSCustomObject]@{
+                    Topic = 'IncorrectPath'
+                    Path  = 'Module\Group\AboutSomethingIncorrectPath.Koans.ps1'
+                }
+                [PSCustomObject]@{
+                    Topic = 'Existing'
+                    Path  = 'Module\Group\AboutSomethingExisting.Koans.ps1'
+                }
+            }
+
+            Mock 'Get-PSKoan' -ParameterFilter { $Scope -eq 'User' } -MockWith {
+                [PSCustomObject]@{
+                    Topic = 'IncorrectPath'
+                    Path  = 'Module\RetiredGroup\AboutSomethingIncorrectPath.Koans.ps1'
+                }
+                [PSCustomObject]@{
+                    Topic = 'RetiredTopic'
+                    Path  = 'Module\RetiredGroup\AboutSomethingRetiredTopic.Koans.ps1'
+                }
+                [PSCustomObject]@{
+                    Topic = 'Existing'
+                    Path  = 'Module\Group\AboutSomethingExisting.Koans.ps1'
+                }
+            }
+        }
+
+        It 'should not produce output' {
+            Update-PSKoan -Confirm:$false | Should -BeNullOrEmpty
+        }
+
+        It 'should copy missing topic files' {
+            Should -Invoke 'Copy-Item' -Times 1 -Scope Context
+        }
+
+        It 'should move incorrectly placed topics' {
+            Should -Invoke 'Remove-Item' -Times 1 -Scope Context
+        }
+
+        It 'should remove discarded topics' {
+            Should -Invoke 'Remove-Item' -Times 1 -Scope Context
+        }
+
+        It 'should update topics which exist in module and koan path' {
+            Should -Invoke 'Update-PSKoanFile' -ModuleName 'PSKoans' -Times 2 -Scope Context
+        }
+    }
+
+    Context 'Practical Tests with TestDrive' {
+
+        BeforeAll {
+            Mock 'Get-PSKoanLocation' {
                 Join-Path -Path $TestDrive -ChildPath 'PSKoans'
             }
+
             New-Item -Path (Get-PSKoanLocation) -ItemType Directory
+            Update-PSKoan -Confirm:$false
+
+            $file = Get-ChildItem -Path (Get-PSKoanLocation) -Filter *.koans.ps1 -File -Recurse |
+                Select-Object -First 1
         }
 
-        Context 'Mocked Commands' {
-            BeforeAll {
-                Mock Remove-Item
-                Mock Copy-Item
-                Mock New-Item
-                Mock Move-Item
-                Mock Update-PSKoanFile
+        It 'should copy missing topic files' {
+            $file | Remove-Item
+            $file.FullName | Should -Not -Exist
 
-                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'Module' } -MockWith {
-                    [PSCustomObject]@{
-                        Topic = 'Missing'
-                        Path  = 'Module\Group\AboutSomethingMissing.Koans.ps1'
-                    }
-                    [PSCustomObject]@{
-                        Topic = 'IncorrectPath'
-                        Path  = 'Module\Group\AboutSomethingIncorrectPath.Koans.ps1'
-                    }
-                    [PSCustomObject]@{
-                        Topic = 'Existing'
-                        Path  = 'Module\Group\AboutSomethingExisting.Koans.ps1'
-                    }
-                }
-                Mock Get-PSKoan -ParameterFilter { $Scope -eq 'User' } -MockWith {
-                    [PSCustomObject]@{
-                        Topic = 'IncorrectPath'
-                        Path  = 'Module\RetiredGroup\AboutSomethingIncorrectPath.Koans.ps1'
-                    }
-                    [PSCustomObject]@{
-                        Topic = 'RetiredTopic'
-                        Path  = 'Module\RetiredGroup\AboutSomethingRetiredTopic.Koans.ps1'
-                    }
-                    [PSCustomObject]@{
-                        Topic = 'Existing'
-                        Path  = 'Module\Group\AboutSomethingExisting.Koans.ps1'
-                    }
-                }
-            }
+            Update-PSKoan -Confirm:$false
 
-            It 'should not produce output' {
-                Update-PSKoan -Confirm:$false | Should -BeNullOrEmpty
-            }
-
-            It 'should copy missing topic files' {
-                Assert-MockCalled Copy-Item -Times 1
-            }
-
-            It 'should move incorrectly placed topics' {
-                Assert-MockCalled Remove-Item -Times 1
-            }
-
-            It 'should remove discarded topics' {
-                Assert-MockCalled Remove-Item -Times 1
-            }
-
-            It 'should update topics which exist in module and koan path' {
-                Assert-MockCalled Update-PSKoanFile -Times 2
-            }
+            $file.FullName | Should -Exist
         }
 
-        Context 'Practical Tests with TestDrive' {
-            BeforeAll {
-                Update-PSKoan -Confirm:$false
+        It 'should move incorrectly placed topics' {
+            $directory = New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'PSKoans\Wrong') -ItemType Directory
+            $file | Move-Item -Destination $directory.FullName
+            $file.FullName | Should -Not -Exist
 
-                $file = Get-ChildItem -Path (Get-PSKoanLocation) -Filter *.koans.ps1 -File -Recurse |
-                    Select-Object -First 1
-            }
+            Update-PSKoan -Confirm:$false
 
-            It 'should copy missing topic files' {
-                $file | Remove-Item
-                $file.FullName | Should -Not -Exist
+            $file.FullName | Should -Exist
+        }
 
-                Update-PSKoan -Confirm:$false
+        It 'should remove discarded topics' {
+            $oldTopicPath = Join-Path $TestDrive 'PSKoans\Foundations\OldTopic.koans.ps1'
+            $file | Copy-Item -Destination $oldTopicPath
+            $oldTopicPath | Should -Exist
 
-                $file.FullName | Should -Exist
-            }
+            Update-PSKoan -Confirm:$false
 
-            It 'should move incorrectly placed topics' {
-                $directory = New-Item -Path (Join-Path -Path $TestDrive -ChildPath 'PSKoans\Wrong') -ItemType Directory
-                $file | Move-Item -Destination $directory.FullName
-                $file.FullName | Should -Not -Exist
-
-                Update-PSKoan -Confirm:$false
-
-                $file.FullName | Should -Exist
-            }
-
-            It 'should remove discarded topics' {
-                $oldTopicPath = Join-Path $TestDrive 'PSKoans\Foundations\OldTopic.koans.ps1'
-                $file | Copy-Item -Destination $oldTopicPath
-                $oldTopicPath | Should -Exist
-
-                Update-PSKoan -Confirm:$false
-
-                $oldTopicPath | Should -Not -Exist
-            }
+            $oldTopicPath | Should -Not -Exist
         }
     }
 }

--- a/Tests/KoanValidation.Tests.ps1
+++ b/Tests/KoanValidation.Tests.ps1
@@ -3,33 +3,27 @@
 using namespace System.Management.Automation.Language
 using namespace System.Collections.Generic
 
-$ProjectRoot = Resolve-Path "$PSScriptRoot/.."
-$KoanFolder = $ProjectRoot |
-    Join-Path -ChildPath 'PSKoans' -AdditionalChildPath 'Koans'
-
-Describe 'Koan Topics Static Analysis Checks' {
+Describe 'Static Analysis: Koan Topics' {
 
     Context 'Individual Topics' {
 
-        BeforeAll {
-            # TestCases are splatted to the script so we need hashtables
-            $KoanTopics = Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.Koans.ps1' |
-                ForEach-Object {
-                    $commandInfo = Get-Command -Name $_.FullName -ErrorAction SilentlyContinue
-                    $koanAttribute = $commandInfo.ScriptBlock.Attributes.Where{ $_.TypeID -match 'Koan' }
+        #region Discovery
+        $KoanTopics = Resolve-Path "$PSScriptRoot/../PSKoans/Koans" |
+            Get-ChildItem -Recurse -Filter '*.Koans.ps1' |
+            ForEach-Object {
+                $commandInfo = Get-Command -Name $_.FullName -ErrorAction SilentlyContinue
+                $koanAttribute = $commandInfo.ScriptBlock.Attributes.Where{ $_.TypeID -match 'Koan' }
 
-                    @{
-                        File     = $_
-                        Name     = $_.BaseName -replace '\.Koans$'
-                        Position = $koanAttribute.Position
-                        Module   = $koanAttribute.Module
-                    }
+                @{
+                    File     = $_
+                    Name     = $_.BaseName -replace '\.Koans$'
+                    Position = $koanAttribute.Position
+                    Module   = $koanAttribute.Module
                 }
-        }
+            }
+        #endregion Discovery
 
-        It 'Koan Topic <Name> should be valid powershell' -TestCases $KoanTopics {
-            param($File)
-
+        It 'has no syntax errors in <Topic>' -TestCases $KoanTopics {
             $File.FullName | Should -Exist
 
             $Errors = $Tokens = $null
@@ -37,9 +31,7 @@ Describe 'Koan Topics Static Analysis Checks' {
             $Errors.Count | Should -Be 0
         }
 
-        It 'Koan Topic <Name> should not have nested It blocks' -TestCases $KoanTopics {
-            param($File)
-
+        It 'does not have nested It blocks in <Topic>' -TestCases $KoanTopics {
             function Test-ItBlock {
                 [CmdletBinding()]
                 param([Ast] $element)
@@ -86,14 +78,12 @@ Describe 'Koan Topics Static Analysis Checks' {
             $ParentItBlocks | Should -BeNullOrEmpty -Because 'It blocks cannot be nested'
         }
 
-        It 'Koan Topic <Name> should include one (and only one) line feed at end of file' -TestCases $KoanTopics {
-            param($File)
-
+        It 'has exactly one line feed at end of the <Topic> file' -TestCases $KoanTopics {
             $crlf = [Regex]::Match(($File | Get-Content -Raw), '(\r?(?<lf>\n))+\Z')
             $crlf.Groups['lf'].Captures.Count | Should -Be 1
         }
 
-        It 'Koan Topic <Name> should have a Koan position' -TestCases $KoanTopics {
+        It 'has a position number defined for <Topic>' -TestCases $KoanTopics {
             param($File, $Position)
 
             $Position | Should -Not -BeNullOrEmpty
@@ -103,9 +93,23 @@ Describe 'Koan Topics Static Analysis Checks' {
 
     Context 'Library Cleanliness' {
 
-        It 'should not have topics with duplicate Koan positions' {
-            $DuplicatePosition = $KoanTopics |
-                ForEach-Object { [PSCustomObject]$_ } |
+        BeforeAll {
+            $KoanFolder = Resolve-Path "$PSScriptRoot/../PSKoans/Koans"
+        }
+
+        It 'does not have topics with duplicate Koan positions' {
+            $DuplicatePosition = Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.Koans.ps1' |
+                ForEach-Object {
+                    $commandInfo = Get-Command -name $_.FullName -ErrorAction SilentlyContinue
+                    $koanAttribute = $commandInfo.ScriptBlock.Attributes.Where{ $_.TypeID -match 'Koan' }
+
+                    [PSCustomObject]@{
+                        File     = $_
+                        Name     = $_.BaseName -replace '\.Koans$'
+                        Position = $koanAttribute.Position
+                        Module   = $koanAttribute.Module
+                    }
+                } |
                 Group-Object { '{0}/{1}' -f $_.Module, $_.Position } |
                 Where-Object Count -gt 1 |
                 ForEach-Object { '{0}: {1}' -f $_.Name, ($_.Group.File -join ', ') }
@@ -113,7 +117,7 @@ Describe 'Koan Topics Static Analysis Checks' {
             $DuplicatePosition | Should -BeNullOrEmpty
         }
 
-        It 'should not have non-Koan Topic files in the Koans directory' {
+        It 'does not have non-Koan Topic files in the Koans directory' {
             Get-ChildItem -Path $KoanFolder -Recurse -Filter '*.ps1' |
                 Where-Object BaseName -notmatch '\.Koans$' |
                 Should -BeNullOrEmpty

--- a/Tests/ModuleValidation.Tests.ps1
+++ b/Tests/ModuleValidation.Tests.ps1
@@ -1,49 +1,52 @@
-$ProjectRoot = Resolve-Path "$PSScriptRoot/.."
-$ModuleRoot = Split-Path (Resolve-Path "$ProjectRoot/*/*.psm1")
-$ModuleName = Split-Path $ModuleRoot -Leaf
+Describe 'Static Analysis: Module & Repository Files' {
 
-Describe "General project validation: $ModuleName" {
-
-    BeforeAll {
-        $FileSearch = @{
-            Path    = $ProjectRoot
-            Include = '*.ps1', '*.psm1', '*.psd1'
-            Recurse = $true
-            Exclude = '*.Koans.ps1'
-        }
-        $Scripts = Get-ChildItem @FileSearch
-
-        # TestCases are splatted to the script so we need hashtables
-        $TestCases = $Scripts | ForEach-Object { @{File = $_ } }
+    #region Discovery
+    $FileSearch = @{
+        Path    = Resolve-Path "$PSScriptRoot/.."
+        Include = '*.ps1', '*.psm1', '*.psd1'
+        Recurse = $true
+        Exclude = '*.Koans.ps1'
     }
+    $Scripts = Get-ChildItem @FileSearch
 
-    It '<File> should be valid powershell' -TestCases $TestCases {
-        param($File)
+    $TestCases = $Scripts | ForEach-Object { @{ File = $_ } }
+    #endregion Discovery
 
-        $File.FullName | Should -Exist
+    Context 'Repository Code' {
 
-        $FileContents = Get-Content -Path $File.FullName -ErrorAction Stop
-        $Errors = $null
-        [System.Management.Automation.PSParser]::Tokenize($FileContents, [ref]$Errors) > $null
-        $Errors.Count | Should -Be 0
-    }
+        It 'has no invalid syntax errors in <File>' -TestCases $TestCases {
+            $File.FullName | Should -Exist
 
-    It '<File> should include one (and only one) line feed at end of file' -TestCases $TestCases {
-        param($File)
-        $crlf = [Regex]::Match(($File | Get-Content -Raw), '(\r?(?<lf>\n))+\Z')
-        $crlf.Groups['lf'].Captures.Count | Should -Be 1
-    }
-
-    It 'can cleanly import the module' {
-        { Import-Module (Join-Path $ModuleRoot "$ModuleName.psm1") -Force } | Should -Not -Throw
-    }
-
-    It 'can remove and re-import the module without errors' {
-        $Script = {
-            Remove-Module $ModuleName
-            Import-Module (Join-Path -Path $ModuleRoot -ChildPath "$ModuleName.psm1")
+            $FileContents = Get-Content -Path $File.FullName -ErrorAction Stop
+            $Errors = $null
+            [System.Management.Automation.PSParser]::Tokenize($FileContents, [ref]$Errors) > $null
+            $Errors.Count | Should -Be 0
         }
 
-        $Script | Should -Not -Throw
+        It 'has exactly one line feed at EOF in <File>' -TestCases $TestCases {
+            $crlf = [Regex]::Match(($File | Get-Content -Raw), '(\r?(?<lf>\n))+\Z')
+            $crlf.Groups['lf'].Captures.Count | Should -Be 1
+        }
+    }
+
+    Context 'Module Import' {
+
+        BeforeAll {
+            $ModuleName = 'PSKoans'
+            $ModuleRoot = (Get-Module -Name $ModuleName).ModuleBase
+        }
+
+        It 'cleanly imports the module' {
+            { Import-Module (Join-Path $ModuleRoot "$ModuleName.psm1") -Force } | Should -Not -Throw
+        }
+
+        It 'removes and re-imports the module without errors' {
+            $Script = {
+                Remove-Module $ModuleName
+                Import-Module (Join-Path -Path $ModuleRoot -ChildPath "$ModuleName.psm1")
+            }
+
+            $Script | Should -Not -Throw
+        }
     }
 }

--- a/formatting/PSKoans.Controls.format.ps1
+++ b/formatting/PSKoans.Controls.format.ps1
@@ -57,7 +57,7 @@ Write-FormatCustomView -AsControl -Name Prompt.Koan -Action {
     Write-FormatViewExpression -ScriptBlock {
         & (Get-Module -Name PSKoans) {
             $ReplacementPattern = '$1    {0} ' -f [char]0x258c
-            (Get-Random -InputObject $script:MeditationStrings) -replace '^|(\r?\n)', $ReplacementPattern
+            ($script:MeditationStrings | Get-Random) -replace '^|(\r?\n)', $ReplacementPattern
         }
     } -ForegroundColor 'PSKoans.Meditation.Emphasis'
 
@@ -123,30 +123,31 @@ Write-FormatCustomView -AsControl -Name Prompt.Details -Action {
     Write-FormatViewExpression -Newline
 
     Write-FormatViewExpression -If {
-        $_.Describe -and
-        $_.Describe -ne $global:_Koan_Describe
+        $_.Block.Name -and
+        $_.Block.Name -ne $global:_Koan_Describe
     } -ScriptBlock {
-        $global:_Koan_Describe = $_.Describe
+        $global:_Koan_Describe = $_.Block.Name
         $Indent = " " * 4
 
-        '{0}Describing {1}{2}' -f $Indent, $_.Describe, [Environment]::NewLine
+        '{0}[+] {1}{2}' -f $Indent, $_.Block.Name, [Environment]::NewLine
     } -ForegroundColor 'PSKoans.Meditation.Text'
 
-    Write-FormatViewExpression -If {
-        $_.Context -and
-        $_.Context -ne $global:_Koan_Context
-    } -ScriptBlock {
-        $global:_Koan_Context = $_.Context
-        $IndentSpaces = 4
-        if ($_.Context) { $IndentSpaces += 2 }
-        $Indent = " " * $IndentSpaces
+    <# OMITTED - Pester v5 doesn't distinguish its blocks (Describe/Context aren't distinguishable)
+        Write-FormatViewExpression -If {
+            $_.Context -and
+            $_.Context -ne $global:_Koan_Context
+        } -ScriptBlock {
+            $global:_Koan_Context = $_.Context
+            $IndentSpaces = 4
+            if ($_.Context) { $IndentSpaces += 2 }
+            $Indent = " " * $IndentSpaces
 
-        '{0}{1}{2}' -f $Indent, $_.Context, [Environment]::NewLine
-    } -ForegroundColor 'PSKoans.Meditation.Emphasis'
-
+            '{0}{1}{2}' -f $Indent, $_.Context, [Environment]::NewLine
+        } -ForegroundColor 'PSKoans.Meditation.Emphasis'
+    #>
     Write-FormatViewExpression -If { $_.Passed } -ScriptBlock {
         $IndentSpaces = 4
-        if ($_.Context) { $IndentSpaces += 4 } elseif ($_.Describe) { $Indent += 2 }
+        if ($_.Block.Name) { $IndentSpaces += 2 } # elseif ($_.Context) { $IndentSpaces += 2 }
         $Indent = " " * $IndentSpaces
 
         '{0}[{1}] It {2}' -f $Indent, [char]0x25b8, $_.Name
@@ -154,7 +155,7 @@ Write-FormatCustomView -AsControl -Name Prompt.Details -Action {
 
     Write-FormatViewExpression -If { -not $_.Passed } -ScriptBlock {
         $IndentSpaces = 4
-        if ($_.Context) { $IndentSpaces += 4 } elseif ($_.Describe) { $Indent += 2 }
+        if ($_.Block.Name) { $IndentSpaces += 2 } # elseif ($_.Context) { $IndentSpaces += 4 }
         $Indent = " " * $IndentSpaces
 
         '{0}[{1}] It {2}' -f $Indent, [char]0xd7, $_.Name

--- a/formatting/PSKoans.Result.format.ps1
+++ b/formatting/PSKoans.Result.format.ps1
@@ -80,7 +80,7 @@ Write-FormatView -TypeName PSKoans.Result -Name Detailed -Action {
 
     Write-FormatViewExpression -ScriptBlock { $_.Results } -ControlName Prompt.Details -Enumerate
 
-    $ExecutionContext.SessionState.PSVariable.Remove("global:_Koan_Describe")
+    $ExecutionContext.SessionState.PSVariable.Remove("global:_Koan_Block_Name")
     # $ExecutionContext.SessionState.PSVariable.Remove("global:_Koan_Context")
 
     Write-FormatViewExpression -If { $_.RequestedTopic.Count -ne 1 } -ControlName Prompt.ProgressBar -ScriptBlock {

--- a/formatting/PSKoans.Result.format.ps1
+++ b/formatting/PSKoans.Result.format.ps1
@@ -80,8 +80,8 @@ Write-FormatView -TypeName PSKoans.Result -Name Detailed -Action {
 
     Write-FormatViewExpression -ScriptBlock { $_.Results } -ControlName Prompt.Details -Enumerate
 
-    $ExecutionContext.SessionState.PSVariable.Remove("Global:_Koan_Describe")
-    $ExecutionContext.SessionState.PSVariable.Remove("Global:_Koan_Context")
+    $ExecutionContext.SessionState.PSVariable.Remove("global:_Koan_Describe")
+    # $ExecutionContext.SessionState.PSVariable.Remove("global:_Koan_Context")
 
     Write-FormatViewExpression -If { $_.RequestedTopic.Count -ne 1 } -ControlName Prompt.ProgressBar -ScriptBlock {
         @{

--- a/templates/environment-setup.yml
+++ b/templates/environment-setup.yml
@@ -17,7 +17,7 @@ steps:
 
       $Params.Name = 'Pester'
       $Params.SkipPublisherCheck = $true
-      $Params.MaximumVersion = '4.99.99'
+      $Params.MinimumVersion = '5.0.2'
       $Params | Out-String | Write-Host
       Install-Module @Params
       $Params.Remove('SkipPublisherCheck')

--- a/templates/environment-setup.yml
+++ b/templates/environment-setup.yml
@@ -21,7 +21,7 @@ steps:
       $Params | Out-String | Write-Host
       Install-Module @Params
       $Params.Remove('SkipPublisherCheck')
-      $Params.Remove('MaximumVersion')
+      $Params.Remove('MinimumVersion')
 
       $Params.Name = 'EZOut'
       $Params.AllowClobber = $true

--- a/templates/install-built-module.yml
+++ b/templates/install-built-module.yml
@@ -28,7 +28,7 @@ steps:
     script: |
       $pesterParams = @{
           Name           = 'Pester'
-          MaximumVersion = '4.99.99'
+          MinimumVersion = '5.0.2'
           ProviderName   = 'NuGet'
           Path           = '${{ parameters.repositoryPath }}'
           Force          = $true


### PR DESCRIPTION
# PR Summary

Need to update the module for Pester v5, likely both the module tests and some of the koans themselves.

## Context

This will resolve #391 fully, but will be a breaking change technically since we have to move to a new major Pester version. Many of the koans should be very compatible with Pester v5, but a complete pass is needed to ensure we aren't using any patterns in the koans that will break in Pester v5.

This also updates the code used in `Measure-Koan` to utilize some internal discovery mechanics of Pester. Unfortunately, using this during an ongoing test run will corrupt Pester's internal state, so the automated tests for this function have been flagged with `-Skip` for the time being, until a solution is found for that.

## Changes

- [x] Update private function tests.
- [x] Update public function tests.
- [x] Update `Get-Karma` to retrieve the correct information from the new Pester result object.
- [x] Update EZOut format handlers to work correctly with the new result object types.
  - [x] Verify these changes are working correctly.
  - [x] Diagnose and resolve issue with formatter on MacOS (formatter only works once, and fails to retrieve meditation/koan flavor text from the module scope for display).
- [x] Review koan topics to ensure they're v5 compatible and make necessary changes.
  - [x] Introduction
  - [x] Foundations
  - [x] Cmdlets 1
  - [x] Cmdlets 2
  - [x] Constructs and Patterns
  - [x] Katas
  - [x] Modules

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
