### PR TITLE
Fix Issue with Modules Koans

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,36 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "PowerShell Launch Current File",
+            "name": "PowerShell Launch Script",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "./Start-DebugSession.ps1",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "PowerShell: Launch Current File",
             "type": "PowerShell",
             "request": "launch",
             "script": "${file}",
-            "args": [],
             "cwd": "${file}"
-        },
-        {
-            "name": "PowerShell Launch Current File in Temporary Console",
-            "type": "PowerShell",
-            "request": "launch",
-            "script": "${file}",
-            "args": [],
-            "cwd": "${file}",
-            "createTemporaryIntegratedConsole": true
-        },
-        {
-            "name": "PowerShell Launch Current File w/Args Prompt",
-            "type": "PowerShell",
-            "request": "launch",
-            "script": "${file}",
-            "args": [
-                "${command:SpecifyScriptArgs}"
-            ],
-            "cwd": "${file}"
-        },
-        {
-            "name": "PowerShell Attach to Host Process",
-            "type": "PowerShell",
-            "request": "attach"
         },
         {
             "name": "PowerShell Interactive Session",
@@ -47,6 +29,12 @@
             "type": "PowerShell",
             "request": "attach",
             "processId": "current"
+        },
+        {
+            "name": "PowerShell Attach to Host Process",
+            "type": "PowerShell",
+            "request": "attach",
+            "runspaceId": 1
         }
     ]
 }

--- a/PSKoans/Private/Invoke-Koan.ps1
+++ b/PSKoans/Private/Invoke-Koan.ps1
@@ -27,12 +27,23 @@
     )
     end {
         try {
-            $Requirements = (Get-Command $ParameterSplat.Script).ScriptBlock.Ast.ScriptRequirements
+            $Requirements = [System.Management.Automation.Language.Parser]::ParseFile(
+                $ParameterSplat.Script,
+                [ref]$null,
+                [ref]$null
+            ).Ast.ScriptRequirements
 
             $Script = {
-                param( $Params, $RequiredModules )
+                param( $Params, $RequiredModules, $PSKoansPath, $PSModulePath )
 
-                . ([scriptblock]::Create('using module PSKoans'))
+                [System.Collections.Generic.HashSet[string]] $ModulePaths = @(
+                    $PSModulePath -split [System.IO.Path]::PathSeparator
+                    $env:PSModulePath -split [System.IO.Path]::PathSeparator
+                )
+
+                $env:PSModulePath = $ModulePaths -join [System.IO.Path]::PathSeparator
+
+                Import-Module $PSKoansPath
                 foreach ($module in $RequiredModules) {
                     Import-Module $module
                 }
@@ -40,22 +51,33 @@
                 Invoke-Pester @Params
             }
 
-            $Thread = [powershell]::Create()
-            $Thread.AddScript($Script) > $null
-            $Thread.AddParameter('Params', $ParameterSplat) > $null
+            $Runspace = [powershell]::Create()
+            $Runspace.AddScript($Script) > $null
+            $Runspace.AddParameter('Params', $ParameterSplat) > $null
+            $Runspace.AddParameter('PSKoansPath', $MyInvocation.MyCommand.Module.ModuleBase) > $null
+            $Runspace.AddParameter('PSModulePath', $env:PSModulePath) > $null
 
             if ($Requirements.RequiredModules) {
-                $Thread.AddParameter('RequiredModules', $Requirements.RequiredModules)
+                $Runspace.AddParameter('RequiredModules', $Requirements.RequiredModules)
             }
 
-            $Status = $Thread.BeginInvoke()
+            $Status = $Runspace.BeginInvoke()
 
             do { Start-Sleep -Milliseconds 1 } until ($Status.IsCompleted)
 
-            $Thread.EndInvoke($Status)
+            $Result = $Runspace.EndInvoke($Status)
+
+            if ($Runspace.HadErrors) {
+                # These will be errors outside the test itself; better propagate them upwards.
+                foreach ($errorItem in $Runspace.Streams.Error) {
+                    $PSCmdlet.WriteError($errorItem)
+                }
+            }
+
+            $Result
         }
         finally {
-            $Thread.Dispose()
+            $Runspace.Dispose()
         }
     }
 }

--- a/PSKoans/Private/Invoke-Koan.ps1
+++ b/PSKoans/Private/Invoke-Koan.ps1
@@ -43,7 +43,7 @@
 
                 $env:PSModulePath = $ModulePaths -join [System.IO.Path]::PathSeparator
 
-                Import-Module $PSKoansPath
+                Get-Module $PSKoansPath -ListAvailable | Import-Module
                 foreach ($module in $RequiredModules) {
                     Import-Module $module
                 }

--- a/PSKoans/Public/Get-PSKoan.ps1
+++ b/PSKoans/Public/Get-PSKoan.ps1
@@ -45,15 +45,19 @@ function Get-PSKoan {
         'Module' { Join-Path -Path $script:ModuleRoot -ChildPath 'Koans' }
     }
 
-    if ($pscmdlet.ParameterSetName -eq 'ListModules') {
-        $moduleList = Join-Path -Path $ParentPath -ChildPath 'Modules' |
-            Get-ChildItem -Directory |
-            Select-Object -ExpandProperty Name
+    if ($PSCmdlet.ParameterSetName -eq 'ListModules') {
+        $modulesPath = Join-Path -Path $ParentPath -ChildPath 'Modules'
 
-        return $moduleList
+        if (Test-Path $modulesPath) {
+            $modulesPath |
+                Get-ChildItem -Directory |
+                Select-Object -ExpandProperty Name
+        }
+
+        return
     }
 
-    $KoanDirectories = switch ($pscmdlet.ParameterSetName) {
+    $KoanDirectories = switch ($PSCmdlet.ParameterSetName) {
         'IncludeModule' {
             $Module = $IncludeModule
             Get-ChildItem $ParentPath -Exclude Modules -Directory
@@ -61,9 +65,11 @@ function Get-PSKoan {
         { $Module } {
             $ModuleRegex = ConvertFrom-WildcardPattern -Pattern $Module
 
-            Join-Path -Path $ParentPath -ChildPath 'Modules' |
-                Get-ChildItem -Directory |
+            $modulesPath = Join-Path -Path $ParentPath -ChildPath 'Modules'
+            if (Test-Path $modulesPath) {
+                Get-ChildItem $modulesPath -Directory |
                 Where-Object { $_.Name -match $ModuleRegex }
+            }
         }
     }
 

--- a/PSKoans/Public/Get-PSKoan.ps1
+++ b/PSKoans/Public/Get-PSKoan.ps1
@@ -68,7 +68,7 @@ function Get-PSKoan {
             $modulesPath = Join-Path -Path $ParentPath -ChildPath 'Modules'
             if (Test-Path $modulesPath) {
                 Get-ChildItem $modulesPath -Directory |
-                Where-Object { $_.Name -match $ModuleRegex }
+                    Where-Object { $_.Name -match $ModuleRegex }
             }
         }
     }

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -97,7 +97,7 @@ function Show-Karma {
                 $KoanLocation | Invoke-Item
             }
         }
-        {$_ -match '^OpenFile'} {
+        { $_ -match '^OpenFile' } {
             # If there is no cached data, we need to call Get-Karma to populate it
             if (-not $script:CurrentTopic -or ($Topic -and $script:CurrentTopic.Name -notlike $Topic)) {
                 try {
@@ -110,7 +110,12 @@ function Show-Karma {
             }
 
             $Editor = Get-PSKoanSetting -Name Editor
-            $FilePath = (Get-PSKoan -Topic $script:CurrentTopic.Name -Scope User).Path
+            $KoanParams = @{
+                Topic         = $script:CurrentTopic.Name
+                IncludeModule = @( $Module; $IncludeModule )
+                Scope         = 'User'
+            }
+            $FilePath = (Get-PSKoan @KoanParams).Path
             $LineNumber = $script:CurrentTopic.CurrentLine
 
             $Arguments = switch ($Editor) {

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -5,9 +5,13 @@ function Show-Karma {
     [Alias('Invoke-PSKoans', 'Test-Koans', 'Get-Enlightenment', 'Meditate', 'Clear-Path', 'Measure-Karma')]
     param(
         [Parameter(ParameterSetName = 'ListKoans')]
+        [Parameter(ParameterSetName = 'ListKoans-ModuleOnly')]
+        [Parameter(ParameterSetName = 'ListKoans-IncludeModule')]
         [Parameter(ParameterSetName = 'ModuleOnly')]
         [Parameter(ParameterSetName = 'IncludeModule')]
         [Parameter(ParameterSetName = 'OpenFile')]
+        [Parameter(ParameterSetName = 'OpenFile-ModuleOnly')]
+        [Parameter(ParameterSetName = 'OpenFile-IncludeModule')]
         [Parameter(ParameterSetName = 'Default')]
         [Alias('Koan', 'File')]
         [SupportsWildcards()]
@@ -15,22 +19,30 @@ function Show-Karma {
         $Topic,
 
         [Parameter(Mandatory, ParameterSetName = 'ModuleOnly')]
-        [Parameter(ParameterSetName = 'ListKoans')]
+        [Parameter(Mandatory, ParameterSetName = 'ListKoans-ModuleOnly')]
+        [Parameter(Mandatory, ParameterSetName = 'OpenFile-ModuleOnly')]
         [SupportsWildcards()]
         [string[]]
         $Module,
 
         [Parameter(Mandatory, ParameterSetName = 'IncludeModule')]
+        [Parameter(Mandatory, ParameterSetName = 'ListKoans-IncludeModule')]
+        [Parameter(Mandatory, ParameterSetName = 'OpenFile-IncludeModule')]
+        [Alias('Meditate')]
         [SupportsWildcards()]
         [string[]]
         $IncludeModule,
 
         [Parameter(Mandatory, ParameterSetName = 'ListKoans')]
+        [Parameter(Mandatory, ParameterSetName = 'ListKoans-ModuleOnly')]
+        [Parameter(Mandatory, ParameterSetName = 'ListKoans-IncludeModule')]
         [Alias('ListKoans', 'ListTopics')]
         [switch]
         $List,
 
         [Parameter(Mandatory, ParameterSetName = 'OpenFile')]
+        [Parameter(Mandatory, ParameterSetName = 'OpenFile-ModuleOnly')]
+        [Parameter(Mandatory, ParameterSetName = 'OpenFile-IncludeModule')]
         [Alias('Meditate')]
         [switch]
         $Contemplate,
@@ -61,7 +73,7 @@ function Show-Karma {
     }
 
     switch ($PSCmdlet.ParameterSetName) {
-        'ListKoans' {
+        { $_ -match '^ListKoans' } {
             Get-PSKoan @GetParams
         }
         'OpenFolder' {
@@ -140,12 +152,12 @@ function Show-Karma {
             try {
                 Get-Karma @GetParams |
                     Format-Custom @FormatParams |
-                    Out-String |
-                    Write-Host
+                    Out-Host
             }
             catch {
                 $PSCmdlet.ThrowTerminatingError($_)
             }
         }
     }
+}
 }

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -28,7 +28,6 @@ function Show-Karma {
         [Parameter(Mandatory, ParameterSetName = 'IncludeModule')]
         [Parameter(Mandatory, ParameterSetName = 'ListKoans-IncludeModule')]
         [Parameter(Mandatory, ParameterSetName = 'OpenFile-IncludeModule')]
-        [Alias('Meditate')]
         [SupportsWildcards()]
         [string[]]
         $IncludeModule,

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -98,7 +98,7 @@ function Show-Karma {
                 $KoanLocation | Invoke-Item
             }
         }
-        'OpenFile' {
+        {$_ -match '^OpenFile'} {
             # If there is no cached data, we need to call Get-Karma to populate it
             if (-not $script:CurrentTopic -or ($Topic -and $script:CurrentTopic.Name -notlike $Topic)) {
                 try {
@@ -159,5 +159,4 @@ function Show-Karma {
             }
         }
     }
-}
 }

--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -66,8 +66,8 @@ function Show-Karma {
 
     $GetParams = @{ }
     switch ($PSCmdlet.ParameterSetName) {
-        'IncludeModule' { $GetParams['IncludeModule'] = $IncludeModule }
-        'ModuleOnly' { $GetParams['Module'] = $Module }
+        { $_ -match 'IncludeModule$' } { $GetParams['IncludeModule'] = $IncludeModule }
+        { $_ -match 'ModuleOnly$' } { $GetParams['Module'] = $Module }
         { $PSBoundParameters.ContainsKey('Topic') } { $GetParams['Topic'] = $Topic }
     }
 

--- a/Start-DebugSession.ps1
+++ b/Start-DebugSession.ps1
@@ -1,0 +1,11 @@
+$env:PSModulePath = $(
+    @(
+        $env:PSModulePath -split [System.IO.Path]::PathSeparator
+        $PSScriptRoot
+    ) | Select-Object -Unique
+) -join [System.IO.Path]::PathSeparator
+
+Import-Module $PSScriptRoot/PSKoans
+
+### Enter code to test below
+Invoke-Pester -Path $PSScriptRoot/Tests/Functions/Public/Show-Karma.Tests.ps1

--- a/Start-DebugSession.ps1
+++ b/Start-DebugSession.ps1
@@ -5,7 +5,7 @@ $env:PSModulePath = $(
     ) | Select-Object -Unique
 ) -join [System.IO.Path]::PathSeparator
 
+& $PSScriptRoot/PSKoans.ezformat.ps1
 Import-Module $PSScriptRoot/PSKoans
 
 ### Enter code to test below
-Invoke-Pester -Path $PSScriptRoot/Tests/Functions/Public/Show-Karma.Tests.ps1

--- a/Tests/Functions/Public/Show-Karma.Tests.ps1
+++ b/Tests/Functions/Public/Show-Karma.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Show-Karma' {
 
         Context 'Default Behaviour' {
             BeforeAll {
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-Karma -ModuleName 'PSKoans' {
                     [PSCustomObject]@{
                         PSTypeName   = 'PSKoans.Result'
@@ -50,7 +50,7 @@ Describe 'Show-Karma' {
             }
 
             It 'should write the formatted output to host' {
-                Assert-MockCalled Write-Host
+                Assert-MockCalled Out-Host
             }
 
             It 'should call Get-Karma to examine the koans' {
@@ -60,7 +60,7 @@ Describe 'Show-Karma' {
 
         Context 'With All Koans Completed' {
             BeforeAll {
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-Karma -ModuleName 'PSKoans' {
                     [PSCustomObject]@{
                         PSTypeName     = 'PSKoans.CompleteResult'
@@ -80,7 +80,7 @@ Describe 'Show-Karma' {
         Context 'With -ClearScreen Switch' {
             BeforeAll {
                 Mock Clear-Host { }
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-Karma -ModuleName 'PSKoans' {
                     [PSCustomObject]@{
                         PSTypeName   = 'PSKoans.Result'
@@ -109,7 +109,7 @@ Describe 'Show-Karma' {
             }
 
             It 'should display the rendered output' {
-                Assert-MockCalled Write-Host
+                Assert-MockCalled Out-Host
             }
 
             It 'should Invoke-Pester on each of the koans' {
@@ -119,7 +119,7 @@ Describe 'Show-Karma' {
 
         Context 'With Nonexistent Koans Folder / No Koans Found' {
             BeforeAll {
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-PSKoan -ModuleName 'PSKoans' { }
                 Mock Update-PSKoan -ModuleName 'PSKoans' { throw 'Prevent recursion' }
                 Mock Write-Warning
@@ -174,7 +174,7 @@ Describe 'Show-Karma' {
 
         Context 'With -Topic Parameter' {
             BeforeAll {
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-Karma -MockWith {
                     [PSCustomObject]@{
                         PSTypeName     = 'PSKoans.Result'
@@ -204,7 +204,7 @@ Describe 'Show-Karma' {
         Context 'With All Koans in a Single Topic Completed' {
             BeforeAll {
                 Mock Format-Custom { $InputObject.Complete }
-                Mock Write-Host { }
+                Mock Out-Host { }
                 Mock Get-Karma -ModuleName 'PSKoans' {
                     [PSCustomObject]@{
                         PSTypeName     = 'PSKoans.CompleteResult'


### PR DESCRIPTION
# PR Summary

There seems to be a few issues with the module koans not running correctly. This PR should resolve those problems.

## Context

Original issues reported by @shaneis on Discord.

## Changes

- Get-PSKoan - Don't write errors when the `Modules` folder is missing; Get-Karma will take the correct action and cause them to be updated anyway, so the error is not useful.
- Invoke-Koan - Check koan script for any requirements before running it and automatically import required modules in the new runspace before invoking Pester.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
