### PR TITLE
Fix 'can be used to select a value for a variable'

### DIFF
--- a/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
@@ -29,7 +29,7 @@ Describe 'If/Else' {
             }
 
             $ExpectedResult = Assert-IsEven -Number 2
-            '____' | Should -Be $ExpectedResult
+            'EVEN' | Should -Be $ExpectedResult
 
             Assert-IsEven -Number __ | Should -Be 'ODD'
         }
@@ -50,7 +50,9 @@ Describe 'If/Else' {
 
         It 'can be used to select a value for a variable' {
             function Get-Thing {
-                return (Get-ChildItem -Path $HOME -File | Select-Object -First 1).Length
+                $file = 'TestDrive:\file.txt'
+                Set-Content -Path $file -Value 'PowerShell is a powerful tool.'
+                return (Get-Item -Path $file).Length
             }
             $Thing = Get-Thing
             $Result = if ($Thing -gt 5) {

--- a/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutConditionals.Koans.ps1
@@ -29,7 +29,7 @@ Describe 'If/Else' {
             }
 
             $ExpectedResult = Assert-IsEven -Number 2
-            'EVEN' | Should -Be $ExpectedResult
+            '____' | Should -Be $ExpectedResult
 
             Assert-IsEven -Number __ | Should -Be 'ODD'
         }


### PR DESCRIPTION
# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

Koan Foundations/AboutConditionals.Koans.ps1 - 'can be used to select a value for a variable'

Fixes #414 

## Context

This PR updates the Koan to create a test file in Pester TestDrive so the Koan no longer uses dynamic system information.

<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

<!--
List any and all changes here, in bullet point form.
-->

* Refactor to use Pester `TestDrive`

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
