### PR TITLE
Get-Member-related koans need to be explained better

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
@@ -45,9 +45,9 @@ Describe 'Get-Help' {
             )
 
             $ParamNames |
-            Group-Object |
-            Where-Object Count -gt 1 |
-            Should -BeNullOrEmpty -Because 'you need to enter unique parameter names'
+                Group-Object |
+                Where-Object Count -gt 1 |
+                Should -BeNullOrEmpty -Because 'you need to enter unique parameter names'
 
             $ParamNames | Should -BeIn $GetHelpParams
         }
@@ -176,8 +176,8 @@ Describe 'Get-Member' {
             $MethodArguments = @('____', '____')
 
             '7', '8', '9', '10' |
-            ForEach-Object -MemberName $MethodName -ArgumentList $MethodArguments |
-            Should -Be @('000007', '000008', '000009', '000010')
+                ForEach-Object -MemberName $MethodName -ArgumentList $MethodArguments |
+                Should -Be @('000007', '000008', '000009', '000010')
         }
     }
 
@@ -265,7 +265,7 @@ Describe 'Get-Command' {
 
     It 'can look for commands by module' {
         $KoanCommands = Get-Command -Module 'PSKoans' |
-        Sort-Object -Property Name
+            Sort-Object -Property Name
         $First4Commands = $KoanCommands | Select-Object -First 4
 
         __ | Should -Be $KoanCommands.Count

--- a/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
@@ -80,10 +80,50 @@ Describe 'Get-Member' {
                     "Hello!" | Get-Member
         
         This will return all of its members. Properties, methods, and other members like 
-        ScriptProperty or ScriptAlias. They will be covered in a separate koan. To make 
-        discovery easier, you can filter by MemberType:
+        ScriptProperty or AliasProperty. They will be covered in a 
+        separate koan. To make discovery easier, you can filter by MemberType:
                     "Hello!" | Get-Member -MemberType Property
                     "Hello!" | Get-Member -MemberType Method
+
+        All possible member types are in the help for Get-Member
+        
+        PS > Get-Help Get-Member -Parameter MemberType
+
+        Specifies the member type that this cmdlet gets. The default is All.
+
+            The acceptable values for this parameter are:
+
+            - AliasProperty
+
+            - CodeProperty
+
+            - Property
+
+            - NoteProperty
+
+            - ScriptProperty
+
+            - Properties
+
+            - PropertySet
+
+            - Method
+
+            - CodeMethod
+
+            - ScriptMethod
+
+            - Methods
+
+            - ParameterizedProperty
+
+            - MemberSet
+
+            - Event
+
+            - Dynamic
+
+            - All
 
     #>
     Context 'Members and methods of objects' {

--- a/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
@@ -75,18 +75,17 @@ Describe 'Get-Member' {
         information about any object in PowerShell. It can be used to inspect the type
         name of an object, as well as all available methods and properties that can be
         accessed for that object.
-        
+
         To use Get-Member, pipe an object into it like so:
                     "Hello!" | Get-Member
-        
-        This will return all of its members. Properties, methods, and other members like 
-        ScriptProperty or AliasProperty. They will be covered in a 
-        separate koan. To make discovery easier, you can filter by MemberType:
+
+        This will return all of its members. Properties, methods, and other members like
+        ScriptProperty or AliasProperty. They will be covered in a separate koan.
+        To make discovery easier, you can filter by MemberType:
                     "Hello!" | Get-Member -MemberType Property
                     "Hello!" | Get-Member -MemberType Method
 
-        All possible member types are in the help for Get-Member
-        
+        All possible member types are in the help for Get-Member:
         PS > Get-Help Get-Member -Parameter MemberType
 
         Specifies the member type that this cmdlet gets. The default is All.
@@ -94,35 +93,20 @@ Describe 'Get-Member' {
             The acceptable values for this parameter are:
 
             - AliasProperty
-
             - CodeProperty
-
             - Property
-
             - NoteProperty
-
             - ScriptProperty
-
             - Properties
-
             - PropertySet
-
             - Method
-
             - CodeMethod
-
             - ScriptMethod
-
             - Methods
-
             - ParameterizedProperty
-
             - MemberSet
-
             - Event
-
             - Dynamic
-
             - All
 
     #>
@@ -154,17 +138,17 @@ Describe 'Get-Member' {
             <#
                 Contrary to properties that represent the state of an object, methods perform actions
                 on the object. Thus, they sometimes need additional information as opposed to
-                properties you can query as is. This is where the parentheses come into play. 
-                Inside the parenthesis you give additional parameters (oftentimes called arguments) 
-                to the method, similary to parameters for a function. In fact, this is how most 
-                programming languages treat functions and methods. If for example you want to 
-                know if a string ends with a certain character, it is necessary that the method knows 
+                properties you can query as is. This is where the parentheses come into play.
+                Inside the parentheses you give additional parameters (oftentimes called arguments)
+                to the method, similary to parameters for a function. In fact, this is how most
+                programming languages treat functions and methods. If for example you want to
+                know if a string ends with a certain character, it is necessary that the method knows
                 which character you want to compare the string against.
 
                 If you have trouble figuring out which parameters a method requires, you can check the
-                OverloadDefinitions by calling the method name without the parentheses (keep in mind 
-                this is NOT asking for a property, but all possible variations of the method). 
-                
+                OverloadDefinitions by calling the method name without the parentheses (keep in mind
+                this is NOT asking for a property, but all possible variations of the method).
+
                 For the above method, these look like this:
 
                 PS> 'string'.EndsWith
@@ -179,10 +163,18 @@ Describe 'Get-Member' {
                 followed by the type and number of arguments it will accept. Only one overload can
                 be used at a time, and usually the number of arguments and type of the arguments
                 determine the overload that PowerShell will apply when calling the method.
+
+                The ForEach-Object cmdlet can be used to call methods as well.
+                This is the same as calling 'Hello!'.$MethodName($MethodArguments),
+                but for each of the strings passed to ForEach-Object:
+
+                PS> 'Hello!', 'Goodbye!' | Foreach-Object -MemberName 'EndsWith' -ArgumentList '!'
+
+                Use Get-Member and the OverloadDefinitions to solve the next tests.
             #>
             $MethodName = '____'
             $MethodArguments = @('____', '____')
-            # The ForEach-Object cmdlet can be used to call methods as well.
+
             '7', '8', '9', '10' |
             ForEach-Object -MemberName $MethodName -ArgumentList $MethodArguments |
             Should -Be @('000007', '000008', '000009', '000010')

--- a/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
@@ -45,9 +45,9 @@ Describe 'Get-Help' {
             )
 
             $ParamNames |
-                Group-Object |
-                Where-Object Count -gt 1 |
-                Should -BeNullOrEmpty -Because 'you need to enter unique parameter names'
+            Group-Object |
+            Where-Object Count -gt 1 |
+            Should -BeNullOrEmpty -Because 'you need to enter unique parameter names'
 
             $ParamNames | Should -BeIn $GetHelpParams
         }
@@ -75,6 +75,16 @@ Describe 'Get-Member' {
         information about any object in PowerShell. It can be used to inspect the type
         name of an object, as well as all available methods and properties that can be
         accessed for that object.
+        
+        To use Get-Member, pipe an object into it like so:
+                    "Hello!" | Get-Member
+        
+        This will return all of its members. Properties, methods, and other members like 
+        ScriptProperty or ScriptAlias. They will be covered in a separate koan. To make 
+        discovery easier, you can filter by MemberType:
+                    "Hello!" | Get-Member -MemberType Property
+                    "Hello!" | Get-Member -MemberType Method
+
     #>
     Context 'Members and methods of objects' {
 
@@ -84,9 +94,6 @@ Describe 'Get-Member' {
             # If you try to access a property that doesn't exist, PowerShell returns $null for it.
             $String.ThisDoesntExist | Should -Be $null
             <#
-                To use Get-Member, pipe an object into it like so:
-                    "Hello!" | Get-Member
-
                 You may need to try some of these in a PowerShell console for yourself to find the best
                 way to solve the problem! Tab-completion can also help you find method and property
                 names; try typing 'string'.<tab> into a console and cycling through the suggested
@@ -103,10 +110,22 @@ Describe 'Get-Member' {
 
             # Methods can be accessed just like properties, but have parentheses and often parameters!
             $String.EndsWith('____') | Should -BeTrue
+
             <#
+                Contrary to properties that represent the state of an object, methods perform actions
+                on the object. Thus, they sometimes need additional information as opposed to
+                properties you can query as is. This is where the parentheses come into play. 
+                Inside the parenthesis you give additional parameters (oftentimes called arguments) 
+                to the method, similary to parameters for a function. In fact, this is how most 
+                programming languages treat functions and methods. If for example you want to 
+                know if a string ends with a certain character, it is necessary that the method knows 
+                which character you want to compare the string against.
+
                 If you have trouble figuring out which parameters a method requires, you can check the
-                OverloadDefinitions by calling the method name without the parentheses. For the above
-                method, these look like this:
+                OverloadDefinitions by calling the method name without the parentheses (keep in mind 
+                this is NOT asking for a property, but all possible variations of the method). 
+                
+                For the above method, these look like this:
 
                 PS> 'string'.EndsWith
 
@@ -125,8 +144,8 @@ Describe 'Get-Member' {
             $MethodArguments = @('____', '____')
             # The ForEach-Object cmdlet can be used to call methods as well.
             '7', '8', '9', '10' |
-                ForEach-Object -MemberName $MethodName -ArgumentList $MethodArguments |
-                Should -Be @('000007', '000008', '000009', '000010')
+            ForEach-Object -MemberName $MethodName -ArgumentList $MethodArguments |
+            Should -Be @('000007', '000008', '000009', '000010')
         }
     }
 
@@ -214,7 +233,7 @@ Describe 'Get-Command' {
 
     It 'can look for commands by module' {
         $KoanCommands = Get-Command -Module 'PSKoans' |
-            Sort-Object -Property Name
+        Sort-Object -Property Name
         $First4Commands = $KoanCommands | Select-Object -First 4
 
         __ | Should -Be $KoanCommands.Count

--- a/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutDiscovery.Koans.ps1
@@ -140,7 +140,7 @@ Describe 'Get-Member' {
                 on the object. Thus, they sometimes need additional information as opposed to
                 properties you can query as is. This is where the parentheses come into play.
                 Inside the parentheses you give additional parameters (oftentimes called arguments)
-                to the method, similary to parameters for a function. In fact, this is how most
+                to the method, similar to parameters for a function. In fact, this is how most
                 programming languages treat functions and methods. If for example you want to
                 know if a string ends with a certain character, it is necessary that the method knows
                 which character you want to compare the string against.

--- a/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
@@ -43,12 +43,7 @@ Describe "Get Member" {
         <#
             Let's look at some object properties!
 
-            Properties define the state an object is in. In traditional object-
-            oriented programming languages, a state of an objet could only be changed
-            by calling provided methods on the object itself. Powershell is more lenient
-            in that you can change the value of a property by setting another value.
-            It is important to keep this distinction in mind for later koans when we
-            explore the .NET library a bit more.  
+            Properties define the state an object is in.
 
             Using any three cmdlets you like (make sure you use three different
             cmdlets!), use Get-Member in your console to peek at the properties
@@ -148,10 +143,9 @@ Describe "Get Member" {
 
     Context 'Exploring Object Methods' {
         <#
-            Contrary to properties that represent the state of an object, methods perform actions
-            on the object. Thus, they sometimes need additional information as opposed to
-            properties you can query as is. This is where the parentheses come into play.
-            Inside the parentheses you give additional parameters (oftentimes called arguments)
+            Now that we know how the state of an object is represented by the values of its properties,
+            we can now take a look at methods. In contrast to properties, methods need parentheses.
+            Inside the parentheses you can give additional parameters (oftentimes called arguments)
             to the method, similary to parameters for a function. In fact, this is how most
             programming languages treat functions and methods. If for example you want to
             know if a string ends with a certain character, it is necessary that the method knows

--- a/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutGetMember.Koans.ps1
@@ -43,6 +43,13 @@ Describe "Get Member" {
         <#
             Let's look at some object properties!
 
+            Properties define the state an object is in. In traditional object-
+            oriented programming languages, a state of an objet could only be changed
+            by calling provided methods on the object itself. Powershell is more lenient
+            in that you can change the value of a property by setting another value.
+            It is important to keep this distinction in mind for later koans when we
+            explore the .NET library a bit more.  
+
             Using any three cmdlets you like (make sure you use three different
             cmdlets!), use Get-Member in your console to peek at the properties
             on the object.
@@ -141,6 +148,15 @@ Describe "Get Member" {
 
     Context 'Exploring Object Methods' {
         <#
+            Contrary to properties that represent the state of an object, methods perform actions
+            on the object. Thus, they sometimes need additional information as opposed to
+            properties you can query as is. This is where the parentheses come into play.
+            Inside the parentheses you give additional parameters (oftentimes called arguments)
+            to the method, similary to parameters for a function. In fact, this is how most
+            programming languages treat functions and methods. If for example you want to
+            know if a string ends with a certain character, it is necessary that the method knows
+            which character you want to compare the string against.
+            
             Similar to above, you can inspect the methods available from an
             object that a cmdlet outputs, by changing the -MemberType value
             you provide to Get-Member:
@@ -166,7 +182,7 @@ Describe "Get Member" {
 
             $Reason = $MethodString -f $MethodName, $CmdletName
             & (Get-Command -Name $CmdletName) |
-                Get-Member -MemberType Property -Name $MethodName |
+                Get-Member -MemberType Method -Name $MethodName |
                 Should -Not -BeNullOrEmpty -Because $Reason
 
             $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
@@ -178,7 +194,7 @@ Describe "Get Member" {
 
             $Reason = $MethodString -f $MethodName, $CmdletName
             & (Get-Command -Name $CmdletName) |
-                Get-Member -MemberType Property -Name $MethodName |
+                Get-Member -MemberType Method -Name $MethodName |
                 Should -Not -BeNullOrEmpty -Because $Reason
 
             $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString
@@ -190,7 +206,7 @@ Describe "Get Member" {
 
             $Reason = $MethodString -f $MethodName, $CmdletName
             & (Get-Command -Name $CmdletName) |
-                Get-Member -MemberType Property -Name $MethodName |
+                Get-Member -MemberType Method -Name $MethodName |
                 Should -Not -BeNullOrEmpty -Because $Reason
 
             $Cmdlets.Add($CmdletName) | Should -BeTrue -Because $UniqueString


### PR DESCRIPTION
# PR Summary

There are examples in AboutDiscovery as well as AboutGetMember that need a better explanation

Fixes #379 

## Context

Newcomers may not be familiar with the intricaciess of methods and properties. This PR intends to enhance the experience users get when solving the koans, by explaining on a surface level the distinction of methods and properties in Powershell and traditional programming languages and how they can interact with Get-Member to solve the koans.

## Changes
- explain properties in OOP 
- explain methods in OOP
- show example usage on how and when to use each
- explain how Get-Member can help when using the membertypes Property and Method

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
