### PR TITLE
AboutCmdletVerbs: Use Join-Path for hardcoded /

### DIFF
--- a/PSKoans/Koans/Introduction/AboutCmdletVerbs.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutCmdletVerbs.Koans.ps1
@@ -22,7 +22,7 @@ Describe "Basic Verbs" {
 
     BeforeAll {
         # We'll be using this path later on.
-        $FilePath = "$env:TMP/YOUR_PATH.txt"
+        $FilePath = Join-Path -Path "$env:TMP" -ChildPath "YOUR_PATH.txt"
 
         if (Test-Path $FilePath) {
             Remove-Item -Path $FilePath

--- a/PSKoans/Koans/Introduction/AboutCmdletVerbs.Koans.ps1
+++ b/PSKoans/Koans/Introduction/AboutCmdletVerbs.Koans.ps1
@@ -22,7 +22,7 @@ Describe "Basic Verbs" {
 
     BeforeAll {
         # We'll be using this path later on.
-        $FilePath = Join-Path -Path "$env:TMP" -ChildPath "YOUR_PATH.txt"
+        $FilePath = Join-Path -Path $TestDrive -ChildPath "YOUR_PATH.txt"
 
         if (Test-Path $FilePath) {
             Remove-Item -Path $FilePath


### PR DESCRIPTION
# PR Summary

Change hardcoded forward slash / in filepath variable into os-dependent path separator with Join-Path

## Context

$FilePath was declared "$env:TMP/YOUR_PATH.txt". This leads to an issue on Windows platforms on the last pester test requesting an error message. While
Powershell itself treats both / and \ without any contempt, the error message expects backslashes for the path. Without Join-Path and its os dependant path separator, the test for the error message can't be fulfilled. The path it checks against is given as (shorthand)

AppData\Local\Temp/YOUR_PATH.txt

due to the koan hardcoding the forward slash into the variable. With Join-Path building the path, it gets resolved correctly as

AppData\Local\Temp\YOUR_PATH.txt

## Changes
"$env:TMP/YOUR_PATH.txt" --> Join-Path -Path "$env:TMP" -ChildPath "YOUR_PATH.txt"

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
