### PR TITLE
Add text editor support for VSCodium, examples for text editor settings

### DIFF
--- a/PSKoans/Public/Show-Karma.ps1
+++ b/PSKoans/Public/Show-Karma.ps1
@@ -119,7 +119,7 @@ function Show-Karma {
             $LineNumber = $script:CurrentTopic.CurrentLine
 
             $Arguments = switch ($Editor) {
-                { $_ -in 'code', 'code-insiders' } {
+                { $_ -in 'code', 'code-insiders', 'codium' } {
                     '--goto'
                     '"{0}":{1}' -f (Resolve-Path $FilePath), $LineNumber
                     '--reuse-window'

--- a/docs/Get-PSKoanSetting.md
+++ b/docs/Get-PSKoanSetting.md
@@ -39,6 +39,14 @@ Get-PSKoanSetting -Name LibraryFolder
 
 Retrieves the library folder location (also retrievable with `Get-PSKoanLocation`).
 
+### EXAMPLE 3
+
+```powershell
+Get-PSKoanSetting -Name Editor
+```
+
+Retrieves the text editor that PSKoans will use for `Show-Karma -Contemplate`.
+
 ## PARAMETERS
 
 ### -Name

--- a/docs/Set-PSKoanSetting.md
+++ b/docs/Set-PSKoanSetting.md
@@ -45,6 +45,16 @@ Set-PSKoanSetting -Name LibraryFolder -Value "./PSKoans"
 
 Sets the library folder location to the `PSKoans` folder in the current directory.
 
+### EXAMPLE 2
+
+```powershell
+Set-PSKoanSetting -Name Editor -Value "atom"
+```
+
+Sets the text editor used for `Show-Karma -Contemplate` to GitHub Atom. For a
+list of text editors known to PSKoans, see Example 2 in the documentation for
+[Show-Karma -Contemplate](https://github.com/vexx32/PSKoans/tree/main/docs/Show-Karma.md).
+
 ## PARAMETERS
 
 ### -Confirm

--- a/docs/Show-Karma.md
+++ b/docs/Show-Karma.md
@@ -99,7 +99,7 @@ Show-Karma -Contemplate
 Opens the current koan file in the editor specified by the `Editor` setting.
 Use `Set-PSKoanSetting` to change the editor used.
 
-If a known editor (`code`, `code-insiders`, or `atom`) is used, PSKoans will pass along line information as well.
+If a known editor (`code`, `code-insiders`, `codium`, or `atom`) is used, PSKoans will pass along line information as well.
 
 ### EXAMPLE 3
 


### PR DESCRIPTION
# PR Summary

This adds text editor support for [VSCodium](https://github.com/VSCodium/vscodium), and adds some general examples for changing the text editor.

## Context

I became aware of this project recently after answering a [question](https://www.reddit.com/r/PowerShell/comments/lhcko2/pskoans_editor_setting) in the *r/PowerShell* subreddit. I noticed the list of known text editors is quite short, and I think it'll be useful to add other commonly used text editors that support line-jumping on the command line. I've started with VSCodium as it accepts the same command line arguments as VSCode, and doesn't require any *functional* changes to how the *Editor* setting is processed, but I'd be happy to include recognition for others like Notepad++, Vim, Sublime Text etc. if there's appetite for it.

I've also added a couple of examples for `Get-PSKoansSetting` and `Set-PSKoansSetting` for reading/changing the text editor setting, as I noticed that there weren't any references to them in the docs for those functions.

As for Pester tests, I don't believe any new ones are required for this change, as the functionality of `Show-Karma` is identical and the [module help tests](https://github.com/vexx32/PSKoans/blob/main/Tests/ModuleHelp.Tests.ps1) cover the docs changes. I did however notice there aren't any in place for the block handling *GitHub Atom*, but this could be rectified later with changes/tests for supporting other text editors.

## Changes

- Add VSCodium text editor support for `Show-Karma -Contemplate`
- Add *codium* to list of known editors in docs for `Show-Karma`
- Add example in docs for `Get-PSKoanSetting` for retrieving editor
- Add example in docs for `Set-PSKoanSetting` for changing editor

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
