### PR TITLE
Fix koan AboutPsProviders

### DIFF
--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -134,6 +134,10 @@ Describe 'Environment Provider' {
 
 Describe 'FileSystem Provider' {
     BeforeAll {
+        if (-not (Test-Path -Path Temp: -PathType Container)){
+            # In PowerShell 5.x the Temp: drive is not defined by default
+            New-PSDrive -Name Temp -PSProvider FileSystem -Root $env:TEMP
+        }
         $Path = 'TEMP:' | Join-Path -ChildPath 'File001.tmp'
 
         $FileContent = @'

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -258,7 +258,7 @@ Describe 'Variable Provider' {
         }
 
         It 'allows you to remove variables' {
-            Set-Variable -name Test -Value 123
+            Set-Variable -Name Test -Value 123
 
             __ | Should -Be $Test
 

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -75,7 +75,7 @@ Describe 'Alias Provider' {
 
         It 'can seek out aliases for a command' {
             $CmdletName = '____'
-            $AliasData = Get-Alias -Definition $CmdletName
+            $AliasData = Get-Alias -Definition $CmdletName -ErrorAction SilentlyContinue
 
             $AliasData.Name | Should -Be 'gcm'
         }

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -268,6 +268,9 @@ Describe 'Variable Provider' {
         }
 
         It 'exposes data from default variables' {
+            if (Test-Path -Path 'Variable:Test') {
+                Remove-Variable -Name Test
+            }
             $Variables = Get-ChildItem -Path 'Variable:'
 
             '____' | Should -Be $Variables.Where{$_.Name -eq 'ConfirmPreference'}.Value

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -260,7 +260,7 @@ Describe 'Variable Provider' {
         It 'allows you to remove variables' {
             Set-Variable -name Test -Value 123
 
-            123 | Should -Be $Test
+            __ | Should -Be $Test
 
             Remove-Item -Path 'Variable:\Test'
             $____ | Should -Be $Test

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -258,6 +258,9 @@ Describe 'Variable Provider' {
         }
 
         It 'allows you to remove variables' {
+            if (Test-Path -Path 'Variable:Test') {
+                Remove-Variable -Name Test
+            }
             $Test = 123
 
             __ | Should -Be $Test
@@ -268,9 +271,6 @@ Describe 'Variable Provider' {
         }
 
         It 'exposes data from default variables' {
-            if (Test-Path -Path 'Variable:Test') {
-                Remove-Variable -Name Test
-            }
             $Variables = Get-ChildItem -Path 'Variable:'
 
             '____' | Should -Be $Variables.Where{$_.Name -eq 'ConfirmPreference'}.Value

--- a/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
+++ b/PSKoans/Koans/Cmdlets 1/AboutPSProviders.Koans.ps1
@@ -258,12 +258,9 @@ Describe 'Variable Provider' {
         }
 
         It 'allows you to remove variables' {
-            if (Test-Path -Path 'Variable:Test') {
-                Remove-Variable -Name Test
-            }
-            $Test = 123
+            Set-Variable -name Test -Value 123
 
-            __ | Should -Be $Test
+            123 | Should -Be $Test
 
             Remove-Item -Path 'Variable:\Test'
             $____ | Should -Be $Test


### PR DESCRIPTION
# PR Summary

Fixes 3 problems in koan AboutPsProviders

* Problem with undersired error message when alias placeholder is no yet replaced (fixes #434)
* Problem with Temp: drive not available in PowerShell 5.1 (fixes #433)
* Problem with variable becoming un-deletable (fixes #435)

## Context

<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

<!--
List any and all changes here, in bullet point form.
-->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
