### PR TITLE
Note that NuGet is only needed on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ View the PSKoans [Command Reference Documentation][reference-docs].
 
 ## Prerequisites
 
-- Windows PowerShell version 5.1 / PowerShell 6+
-- NuGet
+- PowerShell version 5.1 / PowerShell 6+
+- NuGet (Windows only)
 - Pester v4.x
 
-If you've never installed PowerShell modules before, you need to first install the NuGet PackageProvider to enable modules to be installed:
+Windows only: If you've never installed PowerShell modules before, you need to first install the NuGet PackageProvider to enable modules to be installed:
 
 ```PowerShell
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force


### PR DESCRIPTION
# PR Summary

Note that NuGet is needed only on windows.

## Context

I use MacOS, and tried out the PSKoans; the first thing I tried was installing NuGet, as the README told me to.  That failed like this:
```
PS /Users/erichanchrow> Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
Install-PackageProvider: No match was found for the specified search criteria for the provider 'NuGet'. The package provider requires 'PackageManagement' and 'Provider' tags. Please check if the specified package has the tags.
```
Someone on discord told me that NuGet wasn't needed for MacOS, and sure enough, I proceeded to try `Install-Module Pester` and `Install-Module PSKoans`; those both worked, and I'm now happily making my way towards enlightenment.
