### PR TITLE
Fixes #470

### DIFF
--- a/PSKoans/Koans/Constructs and Patterns/AboutRegularExpressions.Koans.ps1
+++ b/PSKoans/Koans/Constructs and Patterns/AboutRegularExpressions.Koans.ps1
@@ -156,15 +156,20 @@ Describe 'Quantifiers' {
     
     Context '*' {
 
+        BeforeEach {
+            $firstTest = ('pears' -match 'p*ears')
+            $secondTest = ('shears' -match 'p*ears')
+        }
+
         It 'specifies 0 or more of something' {
             <#
-                The * character specifies "0 or more" of the symbol or group that comes 
+                The * character specifies "0 or more" of the symbol or group that comes
                 immediately before it. In this case, the pattern can be read aloud as "zero or more
                 of the letter p, then the letters e, a, r, and s."
             #>
-    
-            $____ | Should -Be ('pears' -match 'p*ears')
-            $____ | Should -Be ('shears' -match 'p*ears')
+
+            $____ | Should -Be $firstTest
+            $____ | Should -Be $secondTest
         }
 
         It 'does not need to match the entire string' {


### PR DESCRIPTION
It 'does not need to match the entire string' now has $matches[0] populated without having to test again.

Unsure whether a retest within the following IT statements would be better for flow, but this works.

# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes

<!--
List any and all changes here, in bullet point form.
-->

## Checklist

- [ ] Pull Request has a meaningful title.
- [ ] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
