### PR TITLE
Update Invoke-Pester to use currently supported Configuration

### DIFF
--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -11,8 +11,23 @@ Write-Host "TEST: Pester Version: $PesterVersion"
 Write-Host $Lines
 
 try {
+    $config = [PesterConfiguration]@{
+        Run = @{
+            Path = "$env:PROJECTROOT"
+            Exit = $true
+        }
+        CodeCoverage = @{
+            Enabled = $true
+        }
+        TestResult = @{
+            Enabled = $true
+        }
+        Output = @{
+            Verbosity = 'Normal'
+        }
+    }
     # Try/Finally required since -CI will exit with exit code on failure.
-    Invoke-Pester -Path "$env:PROJECTROOT" -CI -Output Normal
+    Invoke-Pester -Configuration $config
 }
 finally {
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"


### PR DESCRIPTION
This is how we enable code coverage correctly.
With help from: https://pester.dev/docs/commands/Invoke-Pester#-ci

# PR Summary
Attempts to fix failing Azure DevOps CI build (they are timing out).
<!--
Include a brief synopsis of the changes in this section, just outside these comment blocks.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context
No particular context, see failing Azure DevOps pr builds.
<!-- 
Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is.
-->

## Changes
- Switch to using the "Advanced" Invoke-Pester command with configuration to enable code coverage and other required parameters
<!--
List any and all changes here, in bullet point form.
-->

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [x] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [x] Added documentation / opened issue to track adding documentation at a later date.
